### PR TITLE
feat: improve pbinfo unsolved scan UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Build bookmarklet
+        run: npm run build:bookmarklet

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+
+.env
+.env.*
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 
+dist/
+
 .env
 .env.*
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+package-lock.json
+

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100
+}
+

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,4 +3,3 @@
   "trailingComma": "es5",
   "printWidth": 100
 }
-

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ După scanare:
 - Folosește controalele de filtrare (stare + punctaj) pentru a restrânge lista.
 - Folosește butoanele de export pentru a salva rezultatele în CSV/JSON.
 - Poți copia rapid link-urile (lista filtrată) în clipboard.
+- Tabelul are header sticky + highlight la hover și se adaptează automat la dark mode (tema browser-ului).
 
 În timpul scanării poți opri rularea din butonul **Stop scan** (rezultatele parțiale rămân afișate).
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Obține o listă cu problemele nerezolvate de la o categorie de probleme de pe p
 Scriptul va scana paginile din listă și va afișa un tabel + o listă cu problemele care nu sunt rezolvate cu punctaj maxim.
 
 După scanare:
+
 - Folosește controalele de filtrare (stare + punctaj) pentru a restrânge lista.
 - Folosește butoanele de export pentru a salva rezultatele în CSV/JSON.
 - Poți copia rapid link-urile (lista filtrată) în clipboard.
@@ -35,8 +36,8 @@ window.PBINFO_GET_UNSOLVED_START_PAGE = 1; // default 1 (resume: > 1)
 
 // paginare (în caz că pbinfo schimbă parametrii)
 window.PBINFO_GET_UNSOLVED_PAGE_SIZE = 10; // default auto
-window.PBINFO_GET_UNSOLVED_PAGINATION_MODE = "offset"; // "offset" | "page"
-window.PBINFO_GET_UNSOLVED_PAGE_PARAM = "start"; // default "start"
+window.PBINFO_GET_UNSOLVED_PAGINATION_MODE = 'offset'; // "offset" | "page"
+window.PBINFO_GET_UNSOLVED_PAGE_PARAM = 'start'; // default "start"
 window.PBINFO_GET_UNSOLVED_PAGE_BASE = 1; // doar pentru mode="page"
 ```
 
@@ -82,6 +83,14 @@ Lint + format:
 npm run lint
 npm run format
 ```
+
+## Changelog (scurt)
+
+Acest changelog este ținut manual și include doar schimbări majore.
+
+### Unreleased
+
+- Îmbunătățiri la scanare, raportare, export și UI (filtre + dark mode).
 
 ## Issues / sugestii
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ După scanare:
 
 - Folosește controalele de filtrare (stare + punctaj) pentru a restrânge lista.
 - Folosește butoanele de export pentru a salva rezultatele în CSV/JSON.
-- Poți copia rapid link-urile (lista filtrată) în clipboard.
+- Poți copia rapid (lista filtrată) în clipboard: link-uri / ID-uri / Markdown.
 - Tabelul are header sticky + highlight la hover și se adaptează automat la dark mode (tema browser-ului).
 
-În timpul scanării poți opri rularea din butonul **Stop scan** (rezultatele parțiale rămân afișate).
+În timpul scanării poți opri rularea din butonul **Stop scan** sau o poți pune pe pauză (**Pauză/Continuă**); rezultatele parțiale rămân afișate.
 
 ## Config (opțional)
 
@@ -33,6 +33,7 @@ window.PBINFO_GET_UNSOLVED_DELAY_MS = 150; // delay între request-uri (ms), def
 window.PBINFO_GET_UNSOLVED_TIMEOUT_MS = 30000; // default 30000
 window.PBINFO_GET_UNSOLVED_MAX_RETRIES = 3; // default 3
 window.PBINFO_GET_UNSOLVED_START_PAGE = 1; // default 1 (resume: > 1)
+window.PBINFO_GET_UNSOLVED_MAX_PAGES = 5000; // fallback cap (dacă pbinfo nu mai raportează totalul corect)
 
 // paginare (în caz că pbinfo schimbă parametrii)
 window.PBINFO_GET_UNSOLVED_PAGE_SIZE = 10; // default auto

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ window.PBINFO_GET_UNSOLVED_AUTOSAVE_PAGES = 50; // default 50
 window.PBINFO_GET_UNSOLVED_AUTOSAVE_MS = 120000; // default 120000
 
 // mod scanare
-window.PBINFO_GET_UNSOLVED_MODE = 'list'; // "list" | "id-range"
+window.PBINFO_GET_UNSOLVED_MODE = 'list'; // "list" | "id-range" (default în prompt)
+window.PBINFO_GET_UNSOLVED_MODE_PROMPT = true; // default true; setează false ca să sari peste prompt
 window.PBINFO_GET_UNSOLVED_ID_START = 1; // default 1
 window.PBINFO_GET_UNSOLVED_ID_END = 8000; // default 8000
 window.PBINFO_GET_UNSOLVED_ID_MISSING_STOP = 0; // default 0 (dezactivat)

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ Obține o listă cu problemele nerezolvate de la o categorie de probleme de pe p
 1. Intră pe pbinfo.ro și conectează-te la un cont (altfel nu ai punctajul tău pe probleme).
 2. Mergi la lista de probleme pe care vrei să o verifici (o categorie sau lista generală cu filtre).
 3. Deschide consola browser-ului (`Ctrl` + `Shift` + `J`) și rulează scriptul din `pbinfo-get-unsolved-enhanced.js`.
-4. La prompt, apasă `Enter` pentru pagina curentă sau lipește link-ul din bara de adresă și confirmă.
+4. La prompt, apasă `Enter` pentru pagina curentă sau lipește link-ul din bara de adresă și confirmă; apoi alege `start page` (Enter = 1).
 
 Scriptul va scana paginile din listă și va afișa un tabel + o listă cu problemele care nu sunt rezolvate cu punctaj maxim.
 
 După scanare:
 - Folosește controalele de filtrare (stare + punctaj) pentru a restrânge lista.
 - Folosește butoanele de export pentru a salva rezultatele în CSV/JSON.
+- Poți copia rapid link-urile (lista filtrată) în clipboard.
+
+În timpul scanării poți opri rularea din butonul **Stop scan** (rezultatele parțiale rămân afișate).
 
 ## Config (opțional)
 
@@ -27,6 +30,7 @@ window.PBINFO_GET_UNSOLVED_CONCURRENCY = 3; // default 1
 window.PBINFO_GET_UNSOLVED_DELAY_MS = 150; // delay între request-uri (ms), default 0
 window.PBINFO_GET_UNSOLVED_TIMEOUT_MS = 30000; // default 30000
 window.PBINFO_GET_UNSOLVED_MAX_RETRIES = 3; // default 3
+window.PBINFO_GET_UNSOLVED_START_PAGE = 1; // default 1 (resume: > 1)
 
 // paginare (în caz că pbinfo schimbă parametrii)
 window.PBINFO_GET_UNSOLVED_PAGE_SIZE = 10; // default auto

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # pbinfo-get-unsolved
-UPDATED
 
 Obține o listă cu problemele nerezolvate de la o categorie de probleme de pe pbinfo.ro.
 
 ![screenshot](https://user-images.githubusercontent.com/68049793/193668559-2e0f63a8-1d9e-45ea-8839-09b55d1a5608.png)
 
-Pentru a folosi acest script, întâi trebuie să cauți categoria de probleme unde vrei să găsești problemele nerezolvate. Intră pe pbinfo.ro și conectează-te la un cont. Apoi, intră pe una din cele 4 categorii mari de probleme (clasa a IX-a, clasa a X-a, clasa a XI-a, probleme din concursuri), după care intră pe o categorie normală de probleme. Apoi, apasă CTRL + SHIFT + J ca să deschizi consola browser-ului. Aici trebuie să pui scriptul aflat în fișierul `pbinfo-get-unsolved.js` din acest repozitoriu, apoi să apeși enter. Acum script-ul cere link-ul către categoria de probleme, care se găsește în bara de adresă din susul paginii pbinfo.ro. După inserare și acceptare, scriptul va începe să caute probleme nerezolvate din acea categorie.
+## Cum îl folosești
 
-Pentru nelămuriri cu privire la folosirea acestui script sau pentru sugestii, creează un Issue [aici](https://github.com/ezluci/pbinfo-get-unsolved/issues) sau dă-mi mesaj pe Discord (@ezluci) sau pe e-mail (ezluci1@gmail.com). Dacă crezi că acest script îți este util, nu uita să dai o steluță la repozitoriu în colțul din dreapta sus. Mulțumesc!
+1. Intră pe pbinfo.ro și conectează-te la un cont (altfel nu ai punctajul tău pe probleme).
+2. Mergi la lista de probleme pe care vrei să o verifici (o categorie sau lista generală cu filtre).
+3. Deschide consola browser-ului (`Ctrl` + `Shift` + `J`) și rulează scriptul din `pbinfo-get-unsolved-enhanced.js`.
+4. La prompt, lipește link-ul din bara de adresă și confirmă.
+
+Scriptul va scana paginile din listă și va afișa un tabel + o listă cu problemele care nu sunt rezolvate cu punctaj maxim.
+
+## Issues / sugestii
+
+Pentru nelămuriri sau sugestii, creează un Issue în acest repository.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ window.PBINFO_GET_UNSOLVED_PAGE_PARAM = 'start'; // default "start"
 window.PBINFO_GET_UNSOLVED_PAGE_BASE = 1; // doar pentru mode="page"
 ```
 
+Notă: dacă folosești `START_PAGE > 1` în modul `offset` și lista ta are un `PAGE_SIZE` diferit de 10, setează explicit `PBINFO_GET_UNSOLVED_PAGE_SIZE` ca să nu sară pagini.
+
 ## Debug
 
 Dacă scriptul ratează probleme sau nu reușește să identifice punctajul, poți activa un mod de debug (log în consolă).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,31 @@ Obține o listă cu problemele nerezolvate de la o categorie de probleme de pe p
 
 Scriptul va scana paginile din listă și va afișa un tabel + o listă cu problemele care nu sunt rezolvate cu punctaj maxim.
 
+## Debug
+
+Dacă scriptul ratează probleme sau nu reușește să identifice punctajul, poți activa un mod de debug (log în consolă).
+
+Înainte să rulezi scriptul, execută în consolă:
+
+```js
+window.PBINFO_GET_UNSOLVED_DEBUG = true;
+window.PBINFO_GET_UNSOLVED_DEBUG_IDS = [4926, 4928, 4929, 4930, 4936];
+// opțional:
+window.PBINFO_GET_UNSOLVED_DEBUG_LIMIT = 50;
+window.PBINFO_GET_UNSOLVED_DEBUG_HTML = false;
+```
+
+Apoi rulează din nou `pbinfo-get-unsolved-enhanced.js`. Vei primi dump-uri cu ce “vede” parser-ul pentru cardurile respective.
+
+## Development
+
+Rulează testele local:
+
+```bash
+npm install
+npm test
+```
+
 ## Issues / sugestii
 
 Pentru nelămuriri sau sugestii, creează un Issue în acest repository.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,31 @@ Obține o listă cu problemele nerezolvate de la o categorie de probleme de pe p
 1. Intră pe pbinfo.ro și conectează-te la un cont (altfel nu ai punctajul tău pe probleme).
 2. Mergi la lista de probleme pe care vrei să o verifici (o categorie sau lista generală cu filtre).
 3. Deschide consola browser-ului (`Ctrl` + `Shift` + `J`) și rulează scriptul din `pbinfo-get-unsolved-enhanced.js`.
-4. La prompt, lipește link-ul din bara de adresă și confirmă.
+4. La prompt, apasă `Enter` pentru pagina curentă sau lipește link-ul din bara de adresă și confirmă.
 
 Scriptul va scana paginile din listă și va afișa un tabel + o listă cu problemele care nu sunt rezolvate cu punctaj maxim.
+
+După scanare:
+- Folosește controalele de filtrare (stare + punctaj) pentru a restrânge lista.
+- Folosește butoanele de export pentru a salva rezultatele în CSV/JSON.
+
+## Config (opțional)
+
+Poți seta câteva variabile înainte să rulezi scriptul:
+
+```js
+// performanță / rețea
+window.PBINFO_GET_UNSOLVED_CONCURRENCY = 3; // default 1
+window.PBINFO_GET_UNSOLVED_DELAY_MS = 150; // delay între request-uri (ms), default 0
+window.PBINFO_GET_UNSOLVED_TIMEOUT_MS = 30000; // default 30000
+window.PBINFO_GET_UNSOLVED_MAX_RETRIES = 3; // default 3
+
+// paginare (în caz că pbinfo schimbă parametrii)
+window.PBINFO_GET_UNSOLVED_PAGE_SIZE = 10; // default auto
+window.PBINFO_GET_UNSOLVED_PAGINATION_MODE = "offset"; // "offset" | "page"
+window.PBINFO_GET_UNSOLVED_PAGE_PARAM = "start"; // default "start"
+window.PBINFO_GET_UNSOLVED_PAGE_BASE = 1; // doar pentru mode="page"
+```
 
 ## Debug
 
@@ -29,6 +51,17 @@ window.PBINFO_GET_UNSOLVED_DEBUG_HTML = false;
 
 Apoi rulează din nou `pbinfo-get-unsolved-enhanced.js`. Vei primi dump-uri cu ce “vede” parser-ul pentru cardurile respective.
 
+## Bookmarklet (opțional)
+
+Poți genera un bookmarklet minificat:
+
+```bash
+npm install
+npm run build:bookmarklet
+```
+
+Rezultatul este scris în `dist/pbinfo-get-unsolved.bookmarklet.txt`. Copiază conținutul în URL-ul unui bookmark nou, apoi rulează-l pe o pagină pbinfo.
+
 ## Development
 
 Rulează testele local:
@@ -36,6 +69,13 @@ Rulează testele local:
 ```bash
 npm install
 npm test
+```
+
+Lint + format:
+
+```bash
+npm run lint
+npm run format
 ```
 
 ## Issues / sugestii

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ După scanare:
 - Folosește butoanele de export pentru a salva rezultatele în CSV/JSON.
 - Poți copia rapid (lista filtrată) în clipboard: link-uri / ID-uri / Markdown.
 - Tabelul are header sticky + highlight la hover și se adaptează automat la dark mode (tema browser-ului).
-- Poți salva/încărca starea scanării în `localStorage` (util pentru reload-resume).
+- Poți salva/încărca starea scanării în `localStorage` (util pentru reload-resume) + snapshots multiple.
 - Poți schimba tema din UI (sistem/light/dark).
 
 În timpul scanării poți opri rularea din butonul **Stop scan** sau o poți pune pe pauză (**Pauză/Continuă**); rezultatele parțiale rămân afișate.
@@ -52,6 +52,15 @@ window.PBINFO_GET_UNSOLVED_ID_START = 1; // default 1
 window.PBINFO_GET_UNSOLVED_ID_END = 8000; // default 8000
 window.PBINFO_GET_UNSOLVED_ID_MISSING_STOP = 0; // default 0 (dezactivat)
 window.PBINFO_GET_UNSOLVED_ID_LOG_EVERY = 200; // default 200 (log periodic la scanare pe ID)
+window.PBINFO_GET_UNSOLVED_ID_SCORE_BATCH = true; // default true (preluare scoruri în batch)
+window.PBINFO_GET_UNSOLVED_ID_SCORE_BATCH_SIZE = 200; // default 200
+
+// UI
+window.PBINFO_GET_UNSOLVED_OVERLAY = false; // default false (nu șterge pagina, afișează un overlay)
+window.PBINFO_GET_UNSOLVED_LIVE_RENDER = false; // default false (re-randare live, throttled)
+window.PBINFO_GET_UNSOLVED_LIVE_RENDER_EVERY_PAGES = 2; // default 2
+window.PBINFO_GET_UNSOLVED_LIVE_RENDER_MIN_MS = 750; // default 750
+window.PBINFO_GET_UNSOLVED_SNAPSHOTS_MAX = 8; // default 8 (max snapshots per link)
 
 // paginare (în caz că pbinfo schimbă parametrii)
 window.PBINFO_GET_UNSOLVED_PAGE_SIZE = 10; // default auto

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ Obține o listă cu problemele nerezolvate de la o categorie de probleme de pe p
 1. Intră pe pbinfo.ro și conectează-te la un cont (altfel nu ai punctajul tău pe probleme).
 2. Mergi la lista de probleme pe care vrei să o verifici (o categorie sau lista generală cu filtre).
 3. Deschide consola browser-ului (`Ctrl` + `Shift` + `J`) și rulează scriptul din `pbinfo-get-unsolved-enhanced.js`.
-4. La prompt, apasă `Enter` pentru pagina curentă sau lipește link-ul din bara de adresă și confirmă; apoi alege `start page` (Enter = 1).
+4. La prompt, alege modul de scanare:
+   - `1` = scanare listă (paginare)
+   - `2` = scanare interval ID (request-uri la `/probleme/<id>`)
+5. În modul listă: apasă `Enter` pentru pagina curentă sau lipește link-ul din bara de adresă și confirmă; apoi alege `start page` (Enter = 1).
+6. În modul interval ID: alege intervalul (ex: `1-8000`) și `start ID` pentru resume.
+
+Notă: modul interval ID e util când pbinfo nu afișează toate problemele în lista generală/filtrată, dar este mai lent și necesită delay/concurență mică.
 
 Scriptul va scana paginile din listă și va afișa un tabel + o listă cu problemele care nu sunt rezolvate cu punctaj maxim.
 
@@ -39,6 +45,13 @@ window.PBINFO_GET_UNSOLVED_MAX_PAGES = 5000; // fallback cap (dacă pbinfo nu ma
 window.PBINFO_GET_UNSOLVED_AUTOSAVE = true; // default true (autosave în localStorage)
 window.PBINFO_GET_UNSOLVED_AUTOSAVE_PAGES = 50; // default 50
 window.PBINFO_GET_UNSOLVED_AUTOSAVE_MS = 120000; // default 120000
+
+// mod scanare
+window.PBINFO_GET_UNSOLVED_MODE = 'list'; // "list" | "id-range"
+window.PBINFO_GET_UNSOLVED_ID_START = 1; // default 1
+window.PBINFO_GET_UNSOLVED_ID_END = 8000; // default 8000
+window.PBINFO_GET_UNSOLVED_ID_MISSING_STOP = 0; // default 0 (dezactivat)
+window.PBINFO_GET_UNSOLVED_ID_LOG_EVERY = 200; // default 200 (log periodic la scanare pe ID)
 
 // paginare (în caz că pbinfo schimbă parametrii)
 window.PBINFO_GET_UNSOLVED_PAGE_SIZE = 10; // default auto
@@ -100,6 +113,7 @@ Acest changelog este ținut manual și include doar schimbări majore.
 
 - Îmbunătățiri la scanare, raportare, export și UI (filtre + dark mode + theme toggle).
 - Salvare/încărcare stare scanare în `localStorage` (resume după reload).
+- Mod alternativ de scanare: interval ID (`/probleme/<id>`), pentru cazurile în care lista nu include toate problemele.
 
 ## Issues / sugestii
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ După scanare:
 - Folosește butoanele de export pentru a salva rezultatele în CSV/JSON.
 - Poți copia rapid (lista filtrată) în clipboard: link-uri / ID-uri / Markdown.
 - Tabelul are header sticky + highlight la hover și se adaptează automat la dark mode (tema browser-ului).
+- Poți salva/încărca starea scanării în `localStorage` (util pentru reload-resume).
+- Poți schimba tema din UI (sistem/light/dark).
 
 În timpul scanării poți opri rularea din butonul **Stop scan** sau o poți pune pe pauză (**Pauză/Continuă**); rezultatele parțiale rămân afișate.
 
@@ -34,6 +36,9 @@ window.PBINFO_GET_UNSOLVED_TIMEOUT_MS = 30000; // default 30000
 window.PBINFO_GET_UNSOLVED_MAX_RETRIES = 3; // default 3
 window.PBINFO_GET_UNSOLVED_START_PAGE = 1; // default 1 (resume: > 1)
 window.PBINFO_GET_UNSOLVED_MAX_PAGES = 5000; // fallback cap (dacă pbinfo nu mai raportează totalul corect)
+window.PBINFO_GET_UNSOLVED_AUTOSAVE = true; // default true (autosave în localStorage)
+window.PBINFO_GET_UNSOLVED_AUTOSAVE_PAGES = 50; // default 50
+window.PBINFO_GET_UNSOLVED_AUTOSAVE_MS = 120000; // default 120000
 
 // paginare (în caz că pbinfo schimbă parametrii)
 window.PBINFO_GET_UNSOLVED_PAGE_SIZE = 10; // default auto
@@ -93,7 +98,8 @@ Acest changelog este ținut manual și include doar schimbări majore.
 
 ### Unreleased
 
-- Îmbunătățiri la scanare, raportare, export și UI (filtre + dark mode).
+- Îmbunătățiri la scanare, raportare, export și UI (filtre + dark mode + theme toggle).
+- Salvare/încărcare stare scanare în `localStorage` (resume după reload).
 
 ## Issues / sugestii
 

--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,8 @@
 - [ ] Add a pause/resume toggle (keep scan state)
 - [ ] Use `PBINFO_GET_UNSOLVED_MAX_PAGES` as a fallback termination cap
 - [ ] Add extra clipboard formats (IDs / Markdown list)
-- [ ] Add better table styling (sticky header, row hover)
-- [ ] Add dark mode styling for the generated report
+- [x] Add better table styling (sticky header, row hover)
+- [x] Add dark mode styling for the generated report
+- [ ] Add theme toggle (system/light/dark)
 - [ ] Add a small changelog section in README
 - [ ] Add GitHub Actions to run tests on PRs

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 # Project Backlog
 
 ## High priority
+
 - [x] Fix unsolved detection when pbinfo shows max points instead of user score
 - [x] Add robust score parsing (title/data-bs-title variants, multiple numbers like `0/100`)
 - [x] Detect and label statuses: solved / tried / unattempted
@@ -12,6 +13,7 @@
 - [x] Add HTML fixture tests for common pbinfo card layouts
 
 ## Medium priority
+
 - [x] Add UI controls to filter by status and score threshold
 - [x] Add option to export results as CSV/JSON
 - [x] Improve progress reporting (ETA, pages scanned, problems scanned)
@@ -23,6 +25,7 @@
 - [x] Add ESLint + formatting to keep style consistent
 
 ## Low priority
+
 - [x] Add a “copy links to clipboard” button
 - [x] Add a “resume from page N” option
 - [x] Add a “stop scan” button during long runs
@@ -32,5 +35,5 @@
 - [x] Add better table styling (sticky header, row hover)
 - [x] Add dark mode styling for the generated report
 - [ ] Add theme toggle (system/light/dark)
-- [ ] Add a small changelog section in README
-- [ ] Add GitHub Actions to run tests on PRs
+- [x] Add a small changelog section in README
+- [x] Add GitHub Actions to run tests on PRs

--- a/TODO.md
+++ b/TODO.md
@@ -29,9 +29,10 @@
 - [x] Add a “copy links to clipboard” button
 - [x] Add a “resume from page N” option
 - [x] Add a “stop scan” button during long runs
-- [ ] Add a pause/resume toggle (keep scan state)
-- [ ] Use `PBINFO_GET_UNSOLVED_MAX_PAGES` as a fallback termination cap
-- [ ] Add extra clipboard formats (IDs / Markdown list)
+- [x] Add a pause/resume toggle (keep scan state)
+- [x] Use `PBINFO_GET_UNSOLVED_MAX_PAGES` as a fallback termination cap
+- [x] Add extra clipboard formats (IDs / Markdown list)
+- [ ] Persist scan state to `localStorage` for reload-resume
 - [x] Add better table styling (sticky header, row hover)
 - [x] Add dark mode styling for the generated report
 - [ ] Add theme toggle (system/light/dark)

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@
 - [x] Add alternate scan mode by problem ID range (`/probleme/<id>`) to avoid missing items from list filtering
 - [x] Add HTML fixture tests for problem page score cell (`#scor_utilizator_problema`)
 - [x] Consider batched score fetch for ID scans (`ajx-module/json-probleme-scor.php?ids=...`)
+- [x] Skip forbidden problem IDs (HTTP 403) during ID scan instead of aborting
 
 ## Medium priority
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,32 @@
+# Project Backlog
+
+## High priority
+- [x] Fix unsolved detection when pbinfo shows max points instead of user score
+- [x] Add robust score parsing (title/data-bs-title variants, multiple numbers like `0/100`)
+- [ ] Detect and label statuses: solved / tried / unattempted
+- [x] Add request retry/backoff on transient failures and rate limiting
+- [ ] Add safer termination conditions (avoid premature stop on empty/blocked pages)
+- [ ] Add debug mode to dump per-card metadata when parsing fails
+- [x] Update README to reference `pbinfo-get-unsolved-enhanced.js` and current workflow
+- [x] Add regression tests for score parsing heuristics
+- [ ] Add HTML fixture tests for common pbinfo card layouts
+
+## Medium priority
+- [ ] Add UI controls to filter by status and score threshold
+- [ ] Add option to export results as CSV/JSON
+- [ ] Improve progress reporting (ETA, pages scanned, problems scanned)
+- [x] Replace O(n²) duplicate checks with a `Set` of IDs
+- [ ] Add support for both global list and category list URLs with auto-detection
+- [ ] Add configurable page size / pagination strategy (in case pbinfo changes)
+- [ ] Add optional concurrency (limited) for faster scanning
+- [ ] Add a bookmarklet-friendly build (minified single line + instructions)
+- [ ] Add ESLint + formatting to keep style consistent
+
+## Low priority
+- [ ] Add a “copy links to clipboard” button
+- [ ] Add a “resume from page N” option
+- [ ] Add a “stop scan” button during long runs
+- [ ] Add better table styling (sticky header, row hover)
+- [ ] Add dark mode styling for the generated report
+- [ ] Add a small changelog section in README
+- [ ] Add GitHub Actions to run tests on PRs

--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,9 @@
 - [x] Add a “copy links to clipboard” button
 - [x] Add a “resume from page N” option
 - [x] Add a “stop scan” button during long runs
+- [ ] Add a pause/resume toggle (keep scan state)
+- [ ] Use `PBINFO_GET_UNSOLVED_MAX_PAGES` as a fallback termination cap
+- [ ] Add extra clipboard formats (IDs / Markdown list)
 - [ ] Add better table styling (sticky header, row hover)
 - [ ] Add dark mode styling for the generated report
 - [ ] Add a small changelog section in README

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,9 @@
 - [x] Update README to reference `pbinfo-get-unsolved-enhanced.js` and current workflow
 - [x] Add regression tests for score parsing heuristics
 - [x] Add HTML fixture tests for common pbinfo card layouts
+- [x] Add alternate scan mode by problem ID range (`/probleme/<id>`) to avoid missing items from list filtering
+- [x] Add HTML fixture tests for problem page score cell (`#scor_utilizator_problema`)
+- [ ] Consider batched score fetch for ID scans (`ajx-module/json-probleme-scor.php?ids=...`)
 
 ## Medium priority
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,9 +33,14 @@
 - [x] Add a pause/resume toggle (keep scan state)
 - [x] Use `PBINFO_GET_UNSOLVED_MAX_PAGES` as a fallback termination cap
 - [x] Add extra clipboard formats (IDs / Markdown list)
-- [ ] Persist scan state to `localStorage` for reload-resume
+- [x] Persist scan state to `localStorage` for reload-resume
 - [x] Add better table styling (sticky header, row hover)
 - [x] Add dark mode styling for the generated report
-- [ ] Add theme toggle (system/light/dark)
+- [x] Add theme toggle (system/light/dark)
 - [x] Add a small changelog section in README
 - [x] Add GitHub Actions to run tests on PRs
+- [ ] Add throttled live rendering during scan (optional)
+- [ ] Store and select from multiple saved states (per link)
+- [ ] Add unit tests for state snapshot serialization/restore
+- [ ] Add non-destructive overlay UI mode (avoid wiping page)
+- [ ] Add fuzz tests for score parsing / HTML variations

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 - [x] Add HTML fixture tests for common pbinfo card layouts
 - [x] Add alternate scan mode by problem ID range (`/probleme/<id>`) to avoid missing items from list filtering
 - [x] Add HTML fixture tests for problem page score cell (`#scor_utilizator_problema`)
-- [ ] Consider batched score fetch for ID scans (`ajx-module/json-probleme-scor.php?ids=...`)
+- [x] Consider batched score fetch for ID scans (`ajx-module/json-probleme-scor.php?ids=...`)
 
 ## Medium priority
 
@@ -42,8 +42,9 @@
 - [x] Add theme toggle (system/light/dark)
 - [x] Add a small changelog section in README
 - [x] Add GitHub Actions to run tests on PRs
-- [ ] Add throttled live rendering during scan (optional)
-- [ ] Store and select from multiple saved states (per link)
-- [ ] Add unit tests for state snapshot serialization/restore
-- [ ] Add non-destructive overlay UI mode (avoid wiping page)
-- [ ] Add fuzz tests for score parsing / HTML variations
+- [x] Add throttled live rendering during scan (optional)
+- [x] Store and select from multiple saved states (per link)
+- [x] Add unit tests for state snapshot serialization/restore
+- [x] Add non-destructive overlay UI mode (avoid wiping page)
+- [x] Add fuzz tests for score parsing / HTML variations
+- [ ] Add “close overlay” control (when overlay mode enabled)

--- a/TODO.md
+++ b/TODO.md
@@ -3,13 +3,13 @@
 ## High priority
 - [x] Fix unsolved detection when pbinfo shows max points instead of user score
 - [x] Add robust score parsing (title/data-bs-title variants, multiple numbers like `0/100`)
-- [ ] Detect and label statuses: solved / tried / unattempted
+- [x] Detect and label statuses: solved / tried / unattempted
 - [x] Add request retry/backoff on transient failures and rate limiting
-- [ ] Add safer termination conditions (avoid premature stop on empty/blocked pages)
-- [ ] Add debug mode to dump per-card metadata when parsing fails
+- [x] Add safer termination conditions (avoid premature stop on empty/blocked pages)
+- [x] Add debug mode to dump per-card metadata when parsing fails
 - [x] Update README to reference `pbinfo-get-unsolved-enhanced.js` and current workflow
 - [x] Add regression tests for score parsing heuristics
-- [ ] Add HTML fixture tests for common pbinfo card layouts
+- [x] Add HTML fixture tests for common pbinfo card layouts
 
 ## Medium priority
 - [ ] Add UI controls to filter by status and score threshold

--- a/TODO.md
+++ b/TODO.md
@@ -23,9 +23,9 @@
 - [x] Add ESLint + formatting to keep style consistent
 
 ## Low priority
-- [ ] Add a “copy links to clipboard” button
-- [ ] Add a “resume from page N” option
-- [ ] Add a “stop scan” button during long runs
+- [x] Add a “copy links to clipboard” button
+- [x] Add a “resume from page N” option
+- [x] Add a “stop scan” button during long runs
 - [ ] Add better table styling (sticky header, row hover)
 - [ ] Add dark mode styling for the generated report
 - [ ] Add a small changelog section in README

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
 - [x] Add request retry/backoff on transient failures and rate limiting
 - [x] Add safer termination conditions (avoid premature stop on empty/blocked pages)
 - [x] Add debug mode to dump per-card metadata when parsing fails
+- [x] Harden report rendering (avoid `innerHTML` for pbinfo strings)
 - [x] Update README to reference `pbinfo-get-unsolved-enhanced.js` and current workflow
 - [x] Add regression tests for score parsing heuristics
 - [x] Add HTML fixture tests for common pbinfo card layouts

--- a/TODO.md
+++ b/TODO.md
@@ -12,15 +12,15 @@
 - [x] Add HTML fixture tests for common pbinfo card layouts
 
 ## Medium priority
-- [ ] Add UI controls to filter by status and score threshold
-- [ ] Add option to export results as CSV/JSON
-- [ ] Improve progress reporting (ETA, pages scanned, problems scanned)
+- [x] Add UI controls to filter by status and score threshold
+- [x] Add option to export results as CSV/JSON
+- [x] Improve progress reporting (ETA, pages scanned, problems scanned)
 - [x] Replace O(n²) duplicate checks with a `Set` of IDs
-- [ ] Add support for both global list and category list URLs with auto-detection
-- [ ] Add configurable page size / pagination strategy (in case pbinfo changes)
-- [ ] Add optional concurrency (limited) for faster scanning
-- [ ] Add a bookmarklet-friendly build (minified single line + instructions)
-- [ ] Add ESLint + formatting to keep style consistent
+- [x] Add support for both global list and category list URLs with auto-detection
+- [x] Add configurable page size / pagination strategy (in case pbinfo changes)
+- [x] Add optional concurrency (limited) for faster scanning
+- [x] Add a bookmarklet-friendly build (minified single line + instructions)
+- [x] Add ESLint + formatting to keep style consistent
 
 ## Low priority
 - [ ] Add a “copy links to clipboard” button

--- a/TODO.md
+++ b/TODO.md
@@ -48,4 +48,4 @@
 - [x] Add unit tests for state snapshot serialization/restore
 - [x] Add non-destructive overlay UI mode (avoid wiping page)
 - [x] Add fuzz tests for score parsing / HTML variations
-- [ ] Add “close overlay” control (when overlay mode enabled)
+- [x] Add “close overlay” control (when overlay mode enabled)

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,26 @@
+const js = require('@eslint/js');
+const eslintConfigPrettier = require('eslint-config-prettier');
+const globals = require('globals');
+
+module.exports = [
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.{js,cjs,mjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'script',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    rules: {
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
+  },
+  eslintConfigPrettier,
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,214 @@
+{
+  "name": "pbinfo-get-unsolved",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pbinfo-get-unsolved",
+      "devDependencies": {
+        "linkedom": "^0.18.12"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.12",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
+      "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.0.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,356 @@
     "": {
       "name": "pbinfo-get-unsolved",
       "devDependencies": {
-        "linkedom": "^0.18.12"
+        "eslint": "^9.17.0",
+        "eslint-config-prettier": "^9.1.0",
+        "globals": "^15.13.0",
+        "linkedom": "^0.18.12",
+        "prettier": "^3.4.2",
+        "terser": "^5.37.0"
       }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -15,6 +363,100 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -50,6 +492,31 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -125,6 +592,294 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -165,6 +920,131 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/linkedom": {
       "version": "0.18.12",
       "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
@@ -190,6 +1070,56 @@
         }
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -203,12 +1133,292 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
+      "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.46.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
+      "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/uhyphen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
       "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pbinfo-get-unsolved",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "linkedom": "^0.18.12"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,18 @@
   "name": "pbinfo-get-unsolved",
   "private": true,
   "scripts": {
+    "build:bookmarklet": "node scripts/build-bookmarklet.cjs",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
     "test": "node --test"
   },
   "devDependencies": {
-    "linkedom": "^0.18.12"
+    "eslint": "^9.17.0",
+    "eslint-config-prettier": "^9.1.0",
+    "globals": "^15.13.0",
+    "linkedom": "^0.18.12",
+    "prettier": "^3.4.2",
+    "terser": "^5.37.0"
   }
 }

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -359,6 +359,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     style.innerHTML = `
         :root{
             font-family: Arial, sans-serif;
+            color-scheme: light dark;
             --bg: #ffffff;
             --text: #111827;
             --muted: #6b7280;
@@ -391,7 +392,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         #controls{margin:0.75em 0 0.5em;display:flex;flex-wrap:wrap;gap:0.75em;align-items:flex-end;}
         #controls .group{display:flex;flex-direction:column;gap:0.25em;min-width:12em;padding:0.5em;border:1px solid var(--border);border-radius:0.5em;background:var(--panel);}
         #controls label{display:flex;gap:0.4em;align-items:center;user-select:none;}
-        #controls input[type="number"]{width:8em;}
+        #controls input[type="checkbox"]{accent-color:var(--link);}
+        #controls input[type="number"]{width:8em;border:1px solid var(--border);border-radius:0.45em;padding:0.2em 0.35em;background:var(--bg);color:var(--text);}
         #controls button{padding:0.35em 0.65em;border:1px solid var(--border);border-radius:0.45em;background:transparent;color:var(--text);}
         #controls button:hover{background:var(--btn-hover);}
         #controls button:disabled{opacity:0.55;cursor:not-allowed;}

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -169,11 +169,118 @@ function extractScoreInfoFromCard(card) {
   return { userScore, maxScore, candidates };
 }
 
+function extractScoreInfoFromProblemPage(root) {
+  const candidates = [];
+  const cell = root?.querySelector?.('#scor_utilizator_problema');
+  if (!cell) return { userScore: null, maxScore: null, candidates };
+
+  const preferred =
+    cell.querySelector('a.badge, span.badge, a, span, div') || (cell.firstElementChild ?? cell);
+  const text = normalizeSpace(preferred.textContent);
+  const tooltip = getTooltipText(preferred) || getTooltipText(cell);
+  const parsed = parseScoreText(text) || parseScoreText(tooltip);
+  if (parsed) {
+    candidates.push({
+      el: preferred,
+      tooltip,
+      text,
+      value: parsed.value,
+      max: parsed.max,
+      hasRatio: parsed.hasRatio,
+    });
+  }
+
+  const userScore = parsed && Number.isFinite(parsed.value) ? parsed.value : null;
+  const maxScore = parsed && Number.isFinite(parsed.max) ? parsed.max : null;
+  return { userScore, maxScore, candidates };
+}
+
+function extractProblemMetaFromProblemPage(root, problemId) {
+  const meta = {
+    name: '',
+    difficulty: 3,
+    postedBy_link: '',
+    postedBy_name: '',
+    postedBy_img: '',
+    author: '',
+    source: '',
+  };
+
+  const heading = root?.querySelector?.('h1') || root?.querySelector?.('h2');
+  if (heading) {
+    const t = normalizeSpace(heading.textContent);
+    if (t) {
+      const prefixRe = problemId != null ? new RegExp(`^#?\\s*${problemId}\\b\\s*`, 'i') : null;
+      const withoutId = prefixRe ? t.replace(prefixRe, '') : t;
+      meta.name = withoutId.replace(/^[-–—:]\s*/, '').trim();
+    }
+  }
+
+  if (!meta.name) {
+    const ogTitle = root?.querySelector?.('meta[property="og:title"]')?.getAttribute?.('content');
+    const docTitle = root?.querySelector?.('title')?.textContent;
+    const t = normalizeSpace(ogTitle || docTitle);
+    if (t) meta.name = t.replace(/- pbinfo\.ro.*$/i, '').trim();
+  }
+
+  const scoreCell = root?.querySelector?.('#scor_utilizator_problema');
+  const row = scoreCell?.closest?.('tr') || null;
+  const tds = row ? Array.from(row.querySelectorAll('td')) : [];
+  const scoreIdx = scoreCell ? tds.indexOf(scoreCell) : -1;
+
+  const difficultyTd = scoreIdx > 0 ? tds[scoreIdx - 1] : null;
+  if (difficultyTd) {
+    const txt = normalizeForMatch(difficultyTd.textContent);
+    if (txt.includes('uso')) meta.difficulty = 0;
+    else if (txt.includes('med')) meta.difficulty = 1;
+    else if (txt.includes('dific')) meta.difficulty = 2;
+    else if (txt.includes('conc')) meta.difficulty = 3;
+  }
+
+  const authorTd = scoreIdx > 1 ? tds[scoreIdx - 2] : null;
+  if (authorTd) {
+    const a = normalizeSpace(authorTd.textContent);
+    meta.author = a === '-' ? '' : a;
+  }
+
+  const sourceTd = scoreIdx > 2 ? tds[scoreIdx - 3] : null;
+  if (sourceTd) {
+    const s = normalizeSpace(sourceTd.textContent);
+    meta.source = s === '-' ? '' : s;
+  }
+
+  const postedByTd = tds.length > 0 ? tds[0] : null;
+  const pbAnchor = postedByTd?.querySelector?.('a') || null;
+  if (pbAnchor) {
+    meta.postedBy_link = pbAnchor.href || '';
+    meta.postedBy_name = normalizeSpace(pbAnchor.textContent);
+    const img = pbAnchor.querySelector?.('img') || null;
+    if (img?.src) meta.postedBy_img = img.src;
+  }
+
+  return meta;
+}
+
 function classifyProblemStatus(scoreInfo) {
   const maxPoints = Number.isFinite(scoreInfo?.maxScore) ? scoreInfo.maxScore : 100;
   if (scoreInfo?.userScore == null) return 'unattempted';
   if (scoreInfo.userScore >= maxPoints) return 'solved';
   return 'tried';
+}
+
+function isLikelyPbinfoNotFoundHtml(html) {
+  const t = normalizeForMatch(String(html || ''));
+  return t.includes('pagina nu exista') || t.includes('pagina nu există') || t.includes(' 404 ');
+}
+
+function isLikelyPbinfoBlockedHtml(html) {
+  const t = String(html || '');
+  return (
+    /cdn-cgi\/challenge-platform/i.test(t) ||
+    /cf-chl/i.test(t) ||
+    /attention required/i.test(t) ||
+    /security check/i.test(t)
+  );
 }
 
 function parseTotalProblems(html) {
@@ -298,6 +405,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       getTooltipText,
       buildScoreCandidatesFromCard,
       extractScoreInfoFromCard,
+      extractScoreInfoFromProblemPage,
+      extractProblemMetaFromProblemPage,
       classifyProblemStatus,
       parseTotalProblems,
       normalizeListUrl,
@@ -306,6 +415,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       problemsToLinksText,
       problemsToIdsText,
       problemsToMarkdownText,
+      isLikelyPbinfoNotFoundHtml,
+      isLikelyPbinfoBlockedHtml,
     };
   }
 } else {
@@ -377,6 +488,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     }
 
     const config = {
+      scanMode: 'list',
+      idRange: {
+        startId: Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_ID_START))
+          ? Number(window.PBINFO_GET_UNSOLVED_ID_START)
+          : 1,
+        endId: Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_ID_END))
+          ? Number(window.PBINFO_GET_UNSOLVED_ID_END)
+          : 8000,
+        stopAfterMissing: Math.max(
+          0,
+          Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_ID_MISSING_STOP))
+            ? Number(window.PBINFO_GET_UNSOLVED_ID_MISSING_STOP)
+            : 0
+        ),
+      },
       pagination: {
         mode: window.PBINFO_GET_UNSOLVED_PAGINATION_MODE || 'offset',
         param: window.PBINFO_GET_UNSOLVED_PAGE_PARAM || 'start',
@@ -425,25 +551,97 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       ),
     };
 
-    const defaultLink = location?.href || '';
-    let pageLinkInput = prompt(
-      'Pune un link către lista de probleme de unde vrei să obții problemele nerezolvate.\n' +
-        'Enter = pagina curentă. Dacă folosești filtre, copiază link-ul din bara de adrese.',
-      defaultLink
-    );
-    if (pageLinkInput === null) {
-      console.warn('Nu a fost furnizat niciun link. Scriptul a fost oprit.');
-      return;
+    function normalizeScanMode(value) {
+      const v = normalizeForMatch(value || '');
+      if (v.includes('id')) return 'id-range';
+      if (v.includes('range')) return 'id-range';
+      if (v.includes('index')) return 'id-range';
+      if (v.includes('list')) return 'list';
+      return null;
     }
-    pageLinkInput = normalizeSpace(pageLinkInput);
-    const pageLink = normalizeListUrl(
-      pageLinkInput || defaultLink,
-      defaultLink,
-      config.pagination.param
-    );
-    if (!pageLink) {
-      console.warn('Link invalid. Scriptul a fost oprit.');
-      return;
+
+    const defaultLink = location?.href || '';
+    const modeFromWindow = normalizeScanMode(window.PBINFO_GET_UNSOLVED_MODE);
+    let scanMode = modeFromWindow;
+    if (!scanMode) {
+      let modeInput = prompt(
+        'Mod scanare:\n' +
+          '1 = listă (paginare)\n' +
+          '2 = interval ID (probleme/ID)\n' +
+          'Enter = 1',
+        '1'
+      );
+      if (modeInput === null) {
+        console.warn('Nu a fost selectat un mod de scanare. Scriptul a fost oprit.');
+        return;
+      }
+      modeInput = normalizeSpace(modeInput);
+      scanMode = modeInput === '2' ? 'id-range' : 'list';
+    }
+    config.scanMode = scanMode;
+
+    function parseIdRangeInput(value, fallback) {
+      const raw = normalizeSpace(value);
+      const fb = normalizeSpace(fallback);
+      const t = raw || fb;
+      if (!t) return null;
+      const m = /^(\d+)\s*-\s*(\d+)$/.exec(t);
+      if (m) {
+        const startId = parseInt(m[1], 10);
+        const endId = parseInt(m[2], 10);
+        if (!Number.isFinite(startId) || !Number.isFinite(endId) || startId < 1 || endId < 1)
+          return null;
+        return { startId, endId };
+      }
+      const n = parseInt(t, 10);
+      if (!Number.isFinite(n) || n < 1) return null;
+      return { startId: 1, endId: n };
+    }
+
+    let pageLink = null;
+
+    if (scanMode === 'id-range') {
+      const defaultRange = `${config.idRange.startId}-${config.idRange.endId}`;
+      let idRangeInput = prompt(
+        'Interval ID de scanat (ex: 1-8000).\n' +
+          'Notă: scanarea pe ID-uri este mai lentă și poate necesita delay/concurență mică.',
+        defaultRange
+      );
+      if (idRangeInput === null) {
+        console.warn('Nu a fost furnizat intervalul ID. Scriptul a fost oprit.');
+        return;
+      }
+      const range = parseIdRangeInput(idRangeInput, defaultRange);
+      if (!range) {
+        console.warn('Interval ID invalid. Scriptul a fost oprit.');
+        return;
+      }
+      const startId = Math.min(range.startId, range.endId);
+      const endId = Math.max(range.startId, range.endId);
+      config.idRange.startId = startId;
+      config.idRange.endId = endId;
+      pageLink = `id-range:${location?.origin || 'https://www.pbinfo.ro'}:${startId}-${endId}`;
+      config.startPage = startId;
+    } else {
+      let pageLinkInput = prompt(
+        'Pune un link către lista de probleme de unde vrei să obții problemele nerezolvate.\n' +
+          'Enter = pagina curentă. Dacă folosești filtre, copiază link-ul din bara de adrese.',
+        defaultLink
+      );
+      if (pageLinkInput === null) {
+        console.warn('Nu a fost furnizat niciun link. Scriptul a fost oprit.');
+        return;
+      }
+      pageLinkInput = normalizeSpace(pageLinkInput);
+      pageLink = normalizeListUrl(
+        pageLinkInput || defaultLink,
+        defaultLink,
+        config.pagination.param
+      );
+      if (!pageLink) {
+        console.warn('Link invalid. Scriptul a fost oprit.');
+        return;
+      }
     }
 
     const stateKeys = makeStateKeys(pageLink);
@@ -482,10 +680,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           : null;
       const kind = savedFull ? 'full' : 'minimal';
       const note = kind === 'minimal' ? ' (doar progres, fără lista completă)' : '';
+      const unitLabel = scanMode === 'id-range' ? 'ID-uri scanate' : 'Pagini scanate';
+      const headLine =
+        scanMode === 'id-range'
+          ? `Am găsit un scan salvat pentru acest interval${note}.\n`
+          : `Am găsit un scan salvat pentru acest link${note}.\n`;
       const ok = confirm(
-        `Am găsit un scan salvat pentru acest link${note}.\n` +
+        headLine +
           `Salvat la: ${savedAt}\n` +
-          `${pages != null ? `Pagini scanate: ${pages}\n` : ''}` +
+          `${pages != null ? `${unitLabel}: ${pages}\n` : ''}` +
           `${problems != null ? `Probleme scanate: ${problems}\n` : ''}` +
           `\nOK = încarcă, Cancel = ignoră`
       );
@@ -505,20 +708,28 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     }
 
     if (pendingRestore == null) {
-      let startPageInput = prompt(
-        'De la ce pagină să încep scanarea?\n' +
-          '1 = de la început. Pentru resume, pune un număr mai mare.\n' +
-          'Enter = valoarea default.',
-        String(config.startPage)
-      );
+      const promptText =
+        scanMode === 'id-range'
+          ? 'De la ce ID să încep scanarea?\n' +
+            `Interval: ${config.idRange.startId}-${config.idRange.endId}\n` +
+            'Pentru resume, pune un număr mai mare.\n' +
+            'Enter = valoarea default.'
+          : 'De la ce pagină să încep scanarea?\n' +
+            '1 = de la început. Pentru resume, pune un număr mai mare.\n' +
+            'Enter = valoarea default.';
+      let startPageInput = prompt(promptText, String(config.startPage));
       if (startPageInput === null) {
-        console.warn('Nu a fost furnizat start page. Scriptul a fost oprit.');
+        console.warn('Nu a fost furnizat start. Scriptul a fost oprit.');
         return;
       }
       startPageInput = normalizeSpace(startPageInput);
       const startPage = startPageInput === '' ? config.startPage : parseInt(startPageInput, 10);
       if (!Number.isFinite(startPage) || startPage < 1) {
-        console.warn('Start page invalid. Scriptul a fost oprit.');
+        console.warn('Start invalid. Scriptul a fost oprit.');
+        return;
+      }
+      if (scanMode === 'id-range' && startPage > config.idRange.endId) {
+        console.warn('Start ID peste capătul intervalului. Scriptul a fost oprit.');
         return;
       }
       config.startPage = startPage;
@@ -628,8 +839,17 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       window.scroll(0, logDiv.scrollHeight);
     }
 
-    addLog('Link către lista de probleme: <a href="' + pageLink + '"><i>' + pageLink + '</i></a>');
-    addLog(`Start page: <b>${config.startPage}</b>.`);
+    if (scanMode === 'id-range') {
+      addLog(
+        `Mod scanare: <b>interval ID</b> (${config.idRange.startId}-${config.idRange.endId}).`
+      );
+      addLog(`Start ID: <b>${config.startPage}</b>.`);
+    } else {
+      addLog(
+        'Link către lista de probleme: <a href="' + pageLink + '"><i>' + pageLink + '</i></a>'
+      );
+      addLog(`Start page: <b>${config.startPage}</b>.`);
+    }
 
     const progressDiv = document.createElement('div');
     progressDiv.id = 'progress';
@@ -645,10 +865,10 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     let pageSize = config.pageSize;
     let totalProblems = null;
-    let totalPages = null;
+    let totalPages = scanMode === 'id-range' ? config.idRange.endId : null;
     let startedAt = Date.now();
 
-    const stats = { solved: 0, tried: 0, unattempted: 0, total: 0, pages: 0 };
+    const stats = { solved: 0, tried: 0, unattempted: 0, total: 0, pages: 0, missing: 0 };
     let finished = false;
     let scanEnd = null;
     let restoringState = false;
@@ -846,7 +1066,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       summaryDiv.appendChild(b);
       summaryDiv.appendChild(
         document.createTextNode(
-          ` scanate=${total} · nerezolvate=${unsolved} · afișate=${shown} · pagini=${stats.pages}`
+          ` scanate=${total} · nerezolvate=${unsolved} · afișate=${shown} · ${scanMode === 'id-range' ? 'ID-uri' : 'pagini'}=${stats.pages}`
         )
       );
     }
@@ -1280,7 +1500,10 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
       const scanNote = document.createElement('div');
       scanNote.className = 'muted';
-      scanNote.textContent = `resume: start page > 1 (curent ${config.startPage}) · maxPages=${config.maxPages}`;
+      scanNote.textContent =
+        scanMode === 'id-range'
+          ? `resume: start ID > ${config.idRange.startId} (curent ${config.startPage}) · interval=${config.idRange.startId}-${config.idRange.endId}`
+          : `resume: start page > 1 (curent ${config.startPage}) · maxPages=${config.maxPages}`;
       groupScan.appendChild(scanNote);
 
       controlsDiv.replaceChildren(
@@ -1306,8 +1529,28 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     function updateProgress(inFlight) {
       const elapsedMs = Date.now() - startedAt;
-      const pagesDone = stats.pages;
       const scanStart = Math.max(1, Number.isFinite(config.startPage) ? config.startPage : 1);
+      const pauseText = paused ? ' · pauză' : '';
+      const inflightText = inFlight > 0 ? ` · în lucru ${inFlight}` : '';
+      const startText = scanStart > 1 ? ` (de la ${scanStart})` : '';
+
+      if (scanMode === 'id-range') {
+        const done = stats.pages;
+        const endId = Number.isFinite(config.idRange.endId) ? config.idRange.endId : null;
+        const totalIds = endId != null ? Math.max(0, endId - scanStart + 1) : null;
+        const idsText = totalIds != null && totalIds > 0 ? `${done}/${totalIds}` : `${done}`;
+        const speed = elapsedMs > 0 ? done / (elapsedMs / 1000) : 0;
+        const etaMs =
+          totalIds != null && totalIds > 0 && speed > 0 ? ((totalIds - done) / speed) * 1000 : null;
+        const etaText = etaMs != null ? ` · ETA ~${formatDuration(etaMs)}` : '';
+        const missingText = stats.missing > 0 ? ` · 404 ${stats.missing}` : '';
+        progressDiv.textContent = `Progres: ID-uri ${idsText}, probleme ${stats.total} (găsite)${missingText} · timp ${formatDuration(
+          elapsedMs
+        )}${etaText}${pauseText}${inflightText}${startText}`;
+        return;
+      }
+
+      const pagesDone = stats.pages;
       const scanPagesTotal = Number.isFinite(totalPages)
         ? Math.max(0, totalPages - scanStart + 1)
         : null;
@@ -1331,9 +1574,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           ? ((scanPagesTotal - pagesDone) / speed) * 1000
           : null;
       const etaText = etaMs != null ? ` · ETA ~${formatDuration(etaMs)}` : '';
-      const pauseText = paused ? ' · pauză' : '';
-      const inflightText = inFlight > 0 ? ` · în lucru ${inFlight}` : '';
-      const startText = scanStart > 1 ? ` (de la ${scanStart})` : '';
+
       progressDiv.textContent = `Progres: pagini ${pagesText}, probleme ${probsText} · timp ${formatDuration(
         elapsedMs
       )}${etaText}${pauseText}${inflightText}${startText}`;
@@ -1485,7 +1726,10 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       ensureResultsAttached();
       renderResults();
 
-      const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, pagini ${stats.pages}).`;
+      const unitLabel = scanMode === 'id-range' ? 'ID-uri' : 'pagini';
+      const missingSuffix =
+        scanMode === 'id-range' && stats.missing > 0 ? `, 404 ${stats.missing}` : '';
+      const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, ${unitLabel} ${stats.pages}${missingSuffix}).`;
       addLog(summary);
 
       const unsolvedCount = allProblems.filter((p) => p.status !== 'solved').length;
@@ -1511,6 +1755,14 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     let nextSequentialPage = null;
     let queueInitialized = false;
     let inFlight = 0;
+    let idRangeConsecutiveMissing = 0;
+    let idRangeWarnedAboutScore = false;
+    const idRangeLogEvery = Math.max(
+      50,
+      Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_ID_LOG_EVERY))
+        ? Number(window.PBINFO_GET_UNSOLVED_ID_LOG_EVERY)
+        : 200
+    );
 
     const autosaveConfig = {
       enabled: window.PBINFO_GET_UNSOLVED_AUTOSAVE !== false,
@@ -1612,6 +1864,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         version: STATE_STORAGE_VERSION,
         storageLevel: level,
         savedAt: now,
+        scanMode,
+        idRange: scanMode === 'id-range' ? { ...config.idRange } : null,
         pageLink,
         pagination: { ...config.pagination },
         scanStartPage: config.startPage,
@@ -1706,6 +1960,14 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             config.pagination.pageBase = state.pagination.pageBase;
         }
 
+        if (scanMode === 'id-range' && state.idRange && typeof state.idRange === 'object') {
+          if (Number.isFinite(state.idRange.startId))
+            config.idRange.startId = state.idRange.startId;
+          if (Number.isFinite(state.idRange.endId)) config.idRange.endId = state.idRange.endId;
+          if (Number.isFinite(state.idRange.stopAfterMissing))
+            config.idRange.stopAfterMissing = state.idRange.stopAfterMissing;
+        }
+
         if (Number.isFinite(state.scanStartPage)) config.startPage = state.scanStartPage;
 
         const elapsed = Number.isFinite(state.elapsedMs) ? state.elapsedMs : null;
@@ -1723,6 +1985,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             : 0;
           stats.total = Number.isFinite(state.stats.total) ? state.stats.total : 0;
           stats.pages = Number.isFinite(state.stats.pages) ? state.stats.pages : 0;
+          stats.missing = Number.isFinite(state.stats.missing) ? state.stats.missing : 0;
         }
 
         allProblems.length = 0;
@@ -1936,9 +2199,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       if (queueInitialized) return;
       if (!Number.isFinite(totalPages)) return;
       const startAt = Math.max(1, Number.isFinite(config.startPage) ? config.startPage : 1);
-      const cap = Number.isFinite(config.maxPages) ? config.maxPages : null;
+      const cap = scanMode === 'list' && Number.isFinite(config.maxPages) ? config.maxPages : null;
       const cappedTotalPages = cap != null ? Math.min(totalPages, cap) : totalPages;
-      if (cappedTotalPages < totalPages) {
+      if (scanMode === 'list' && cappedTotalPages < totalPages) {
         addLog(
           `<span style="color:#b35c00;"><b>Atenție:</b> totalPages=${totalPages} depășește maxPages=${cap}. Voi scana doar primele ${cappedTotalPages} pagini.</span>`
         );
@@ -1958,7 +2221,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         deferPage(pageIndex, retryCount);
         return;
       }
-      if (Number.isFinite(config.maxPages) && pageIndex > config.maxPages) {
+      if (scanMode === 'list' && Number.isFinite(config.maxPages) && pageIndex > config.maxPages) {
         pageQueue.length = 0;
         deferredPageRequests.clear();
         finishScan({
@@ -1986,14 +2249,20 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         updateProgress(inFlight);
       };
       const effectivePageSize = Number.isFinite(pageSize) ? pageSize : 10;
-      const startOffset = effectivePageSize * (pageIndex - 1);
-      const url = buildPageUrl(pageLink, {
-        pageIndex,
-        pageSize: effectivePageSize,
-        mode: config.pagination.mode,
-        param: config.pagination.param,
-        pageBase: config.pagination.pageBase,
-      });
+      const startOffset = scanMode === 'list' ? effectivePageSize * (pageIndex - 1) : null;
+      const url =
+        scanMode === 'id-range'
+          ? new URL(
+              `/probleme/${pageIndex}`,
+              location?.origin || 'https://www.pbinfo.ro'
+            ).toString()
+          : buildPageUrl(pageLink, {
+              pageIndex,
+              pageSize: effectivePageSize,
+              mode: config.pagination.mode,
+              param: config.pagination.param,
+              pageBase: config.pagination.pageBase,
+            });
       xhr.open('GET', url);
       xhr.timeout = config.timeoutMs;
       xhr.onload = () => {
@@ -2002,11 +2271,13 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           finalize();
           return;
         }
-        if (xhr.status !== 200) {
+        const unitLabel = scanMode === 'id-range' ? `ID ${pageIndex}` : `pagina ${pageIndex}`;
+
+        if (isLikelyPbinfoBlockedHtml(responseText)) {
           if (retryCount < maxRetriesPerPage) {
             const delay = 1000 * (retryCount + 1);
             addLog(
-              `Eroare la pagina ${pageIndex} (status ${xhr.status}). Reîncerc în ${delay / 1000}s...`
+              `Serverul a răspuns cu o pagină de verificare (probabil protecție anti-bot) la ${unitLabel}. Reîncerc în ${delay / 1000}s...`
             );
             finalize();
             setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
@@ -2015,7 +2286,56 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           finalize();
           finishScan({
             complete: false,
-            reason: `Eroare la pagina ${pageIndex} (status ${xhr.status})`,
+            reason: `Blocare detectată la ${unitLabel} (posibil Cloudflare). Încearcă delay mai mare și/sau concurență mai mică.`,
+          });
+          return;
+        }
+
+        if (
+          scanMode === 'id-range' &&
+          (xhr.status === 404 || isLikelyPbinfoNotFoundHtml(responseText))
+        ) {
+          stats.pages++;
+          stats.missing++;
+          idRangeConsecutiveMissing++;
+          maybeAutoSave('id');
+          if (
+            config.idRange.stopAfterMissing > 0 &&
+            idRangeConsecutiveMissing >= config.idRange.stopAfterMissing
+          ) {
+            finalize();
+            pageQueue.length = 0;
+            deferredPageRequests.clear();
+            finishScan({
+              complete: false,
+              reason: `Am întâlnit ${idRangeConsecutiveMissing} ID-uri consecutive inexistente. Oprire automată (setare PBINFO_GET_UNSOLVED_ID_MISSING_STOP).`,
+            });
+            return;
+          }
+          if (stats.pages > 0 && stats.pages % idRangeLogEvery === 0) {
+            addLog(
+              `ID ${pageIndex}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}.`
+            );
+          }
+          finalize();
+          schedule(kick);
+          return;
+        }
+
+        if (xhr.status !== 200) {
+          if (retryCount < maxRetriesPerPage) {
+            const delay = 1000 * (retryCount + 1);
+            addLog(
+              `Eroare la ${unitLabel} (status ${xhr.status}). Reîncerc în ${delay / 1000}s...`
+            );
+            finalize();
+            setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+            return;
+          }
+          finalize();
+          finishScan({
+            complete: false,
+            reason: `Eroare la ${unitLabel} (status ${xhr.status})`,
           });
           return;
         }
@@ -2024,7 +2344,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           if (retryCount < maxRetriesPerPage) {
             const delay = 1000 * (retryCount + 1);
             addLog(
-              `Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`
+              `Serverul a răspuns cu "Invalid request" la ${unitLabel}. Reîncerc în ${delay / 1000}s...`
             );
             finalize();
             setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
@@ -2033,8 +2353,95 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           finalize();
           finishScan({
             complete: false,
-            reason: `Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}`,
+            reason: `Serverul a răspuns cu "Invalid request" la ${unitLabel}`,
           });
+          return;
+        }
+
+        if (scanMode === 'id-range') {
+          stats.pages++;
+          idRangeConsecutiveMissing = 0;
+
+          const pageEl = document.createElement('div');
+          pageEl.innerHTML = responseText;
+
+          const canonicalAttr = pageEl
+            .querySelector('link[rel="canonical"]')
+            ?.getAttribute?.('href');
+          const link =
+            canonicalAttr != null
+              ? new URL(canonicalAttr, location?.origin || 'https://www.pbinfo.ro').toString()
+              : new URL(
+                  `/probleme/${pageIndex}`,
+                  location?.origin || 'https://www.pbinfo.ro'
+                ).toString();
+
+          const meta = extractProblemMetaFromProblemPage(pageEl, pageIndex);
+          const scoreInfo = extractScoreInfoFromProblemPage(pageEl);
+          const status = classifyProblemStatus(scoreInfo);
+
+          if (!pageEl.querySelector('#scor_utilizator_problema') && !idRangeWarnedAboutScore) {
+            idRangeWarnedAboutScore = true;
+            addLog(
+              `<span style="color:#b35c00;"><b>Atenție:</b> nu pare să fie disponibil punctajul tău pe pagina problemei (lipsește #scor_utilizator_problema). Verifică dacă ești autentificat pe pbinfo.ro.</span>`
+            );
+          }
+
+          if (!seenProblemIds.has(pageIndex)) {
+            seenProblemIds.add(pageIndex);
+            const scoreKnown = scoreInfo.userScore != null && Number.isFinite(scoreInfo.userScore);
+            const maxScore = Number.isFinite(scoreInfo.maxScore) ? scoreInfo.maxScore : 100;
+            const score = scoreKnown ? scoreInfo.userScore : -1;
+            allProblems.push({
+              cnt: allProblems.length + 1,
+              id: pageIndex,
+              name: meta.name,
+              link,
+              difficulty: meta.difficulty,
+              score,
+              scoreKnown,
+              userScore: scoreInfo.userScore,
+              maxScore,
+              status,
+              postedBy_link: meta.postedBy_link,
+              postedBy_name: meta.postedBy_name,
+              postedBy_img: meta.postedBy_img,
+              author: meta.author,
+              source: meta.source,
+            });
+
+            if (status === 'solved') stats.solved++;
+            else if (status === 'tried') stats.tried++;
+            else stats.unattempted++;
+            stats.total++;
+
+            if (
+              shouldDebugDump(pageIndex) &&
+              (scoreInfo.candidates.length === 0 || status === 'unattempted')
+            ) {
+              debugDumped++;
+              console.log('pbinfo-get-unsolved debug problem page:', {
+                id: pageIndex,
+                name: meta.name,
+                link,
+                scoreInfo: { userScore: scoreInfo.userScore, maxScore: scoreInfo.maxScore },
+                candidates: scoreInfo.candidates,
+              });
+              if (debugIncludeHtml) {
+                console.log('pbinfo-get-unsolved debug problem html:', responseText.slice(0, 5000));
+              }
+            }
+          }
+
+          if (stats.pages > 0 && stats.pages % idRangeLogEvery === 0) {
+            addLog(
+              `ID ${pageIndex}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}.`
+            );
+          }
+
+          maybeAutoSave('id');
+          finalize();
+          schedule(kick);
           return;
         }
 
@@ -2238,29 +2645,34 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       xhr.onabort = () => {
         finalize();
         if (stopRequested || finished || restoringState) return;
-        finishScan({ complete: false, reason: `Request abort la pagina ${pageIndex}` });
+        const unitLabel = scanMode === 'id-range' ? `ID ${pageIndex}` : `pagina ${pageIndex}`;
+        finishScan({ complete: false, reason: `Request abort la ${unitLabel}` });
       };
       xhr.ontimeout = () => {
         finalize();
         if (stopRequested || finished || restoringState) return;
         if (retryCount < maxRetriesPerPage) {
           const delay = 1000 * (retryCount + 1);
-          addLog(`Timeout la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
+          const unitLabel = scanMode === 'id-range' ? `ID ${pageIndex}` : `pagina ${pageIndex}`;
+          addLog(`Timeout la ${unitLabel}. Reîncerc în ${delay / 1000}s...`);
           setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
           return;
         }
-        finishScan({ complete: false, reason: `Timeout la pagina ${pageIndex}` });
+        const unitLabel = scanMode === 'id-range' ? `ID ${pageIndex}` : `pagina ${pageIndex}`;
+        finishScan({ complete: false, reason: `Timeout la ${unitLabel}` });
       };
       xhr.onerror = () => {
         finalize();
         if (stopRequested || finished || restoringState) return;
         if (retryCount < maxRetriesPerPage) {
           const delay = 1000 * (retryCount + 1);
-          addLog(`Eroare de rețea la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
+          const unitLabel = scanMode === 'id-range' ? `ID ${pageIndex}` : `pagina ${pageIndex}`;
+          addLog(`Eroare de rețea la ${unitLabel}. Reîncerc în ${delay / 1000}s...`);
           setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
           return;
         }
-        finishScan({ complete: false, reason: `Eroare de rețea la pagina ${pageIndex}` });
+        const unitLabel = scanMode === 'id-range' ? `ID ${pageIndex}` : `pagina ${pageIndex}`;
+        finishScan({ complete: false, reason: `Eroare de rețea la ${unitLabel}` });
       };
       xhr.send();
     }
@@ -2273,6 +2685,20 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         for (let i = 0; i < config.concurrency; i++) schedule(kick);
       }
     } else {
+      if (scanMode === 'id-range') {
+        const startId = Math.max(1, Number.isFinite(config.startPage) ? config.startPage : 1);
+        const endId = Number.isFinite(config.idRange.endId) ? config.idRange.endId : null;
+        if (endId != null && endId >= startId) {
+          const totalIds = endId - startId + 1;
+          addLog(`Voi scana ID-uri: ${startId}-${endId} (${totalIds} request-uri).`);
+        }
+        if (config.delayMs === 0 && config.concurrency > 1) {
+          addLog(
+            '<span style="color:#b35c00;"><b>Recomandare:</b> pentru scanare pe ID-uri, setează PBINFO_GET_UNSOLVED_DELAY_MS (ex: 150) și concurență mică (1-2), ca să eviți blocarea.</span>'
+          );
+        }
+        initQueueFromTotalPages();
+      }
       fetchPage(config.startPage, 0);
     }
   })();

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -227,6 +227,13 @@ function problemsToCsv(problems) {
     return `\ufeff${lines.join('\n')}`;
 }
 
+function problemsToLinksText(problems) {
+    return (Array.isArray(problems) ? problems : [])
+        .map(p => (p && typeof p.link === 'string' ? p.link.trim() : ''))
+        .filter(Boolean)
+        .join('\n');
+}
+
 if (typeof window === 'undefined' || typeof document === 'undefined') {
     if (typeof module !== 'undefined') {
         module.exports = {
@@ -242,6 +249,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             normalizeListUrl,
             buildPageUrl,
             problemsToCsv,
+            problemsToLinksText,
         };
     }
 } else {
@@ -288,6 +296,12 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 ? Number(window.PBINFO_GET_UNSOLVED_MAX_RETRIES)
                 : 3
         ),
+        startPage: Math.max(
+            1,
+            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_START_PAGE))
+                ? Number(window.PBINFO_GET_UNSOLVED_START_PAGE)
+                : 1
+        ),
         maxPages: Math.max(
             1,
             Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_MAX_PAGES))
@@ -312,6 +326,25 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         console.warn('Link invalid. Scriptul a fost oprit.');
         return;
     }
+
+    let startPageInput = prompt(
+        'De la ce pagină să încep scanarea?\n' +
+            '1 = de la început. Pentru resume, pune un număr mai mare.\n' +
+            'Enter = valoarea default.',
+        String(config.startPage)
+    );
+    if (startPageInput === null) {
+        console.warn('Nu a fost furnizat start page. Scriptul a fost oprit.');
+        return;
+    }
+    startPageInput = normalizeSpace(startPageInput);
+    const startPage = startPageInput === '' ? config.startPage : parseInt(startPageInput, 10);
+    if (!Number.isFinite(startPage) || startPage < 1) {
+        console.warn('Start page invalid. Scriptul a fost oprit.');
+        return;
+    }
+    config.startPage = startPage;
+    const firstFetchedPageIndex = config.startPage;
 
     // wipe the page and setup UI
     document.head.innerHTML = '';
@@ -355,6 +388,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     }
 
     addLog('Link către lista de probleme: <a href="' + pageLink + '"><i>' + pageLink + '</i></a>');
+    addLog(`Start page: <b>${config.startPage}</b>.`);
 
     const progressDiv = document.createElement('div');
     progressDiv.id = 'progress';
@@ -375,6 +409,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     const stats = { solved: 0, tried: 0, unattempted: 0, total: 0, pages: 0 };
     let finished = false;
+    let stopRequested = false;
+    let stopButton = null;
+    const activeRequests = new Set();
 
     const debugEnabled = Boolean(window.PBINFO_GET_UNSOLVED_DEBUG);
     const debugDumpLimit = Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_DEBUG_LIMIT))
@@ -435,6 +472,26 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         if (debugIncludeHtml) {
             console.log('pbinfo-get-unsolved debug card html:', (card.outerHTML || '').slice(0, 5000));
         }
+    }
+
+    async function copyTextToClipboard(text) {
+        const value = String(text || '');
+        if (navigator?.clipboard?.writeText) {
+            await navigator.clipboard.writeText(value);
+            return;
+        }
+        const ta = document.createElement('textarea');
+        ta.value = value;
+        ta.setAttribute('readonly', 'true');
+        ta.style.position = 'fixed';
+        ta.style.top = '-1000px';
+        ta.style.left = '-1000px';
+        document.body.appendChild(ta);
+        ta.focus();
+        ta.select();
+        const ok = document.execCommand('copy');
+        ta.remove();
+        if (!ok) throw new Error('Clipboard copy failed');
     }
 
     const allProblems = [];
@@ -561,6 +618,22 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         setTimeout(() => URL.revokeObjectURL(url), 1000);
     }
 
+    function stopScan(reason) {
+        if (finished) return;
+        stopRequested = true;
+        if (stopButton) {
+            stopButton.disabled = true;
+            stopButton.textContent = 'Oprit';
+        }
+        pageQueue.length = 0;
+        for (const xhr of activeRequests) {
+            try {
+                xhr.abort();
+            } catch {}
+        }
+        finishScan({ complete: false, reason: reason || 'Oprit de utilizator' });
+    }
+
     function setupControls() {
         const groupStatus = document.createElement('div');
         groupStatus.className = 'group';
@@ -664,7 +737,40 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         });
         groupExport.appendChild(exportJson);
 
-        controlsDiv.replaceChildren(groupStatus, groupScore, groupExport);
+        const copyLinks = document.createElement('button');
+        copyLinks.textContent = 'Copiază link-uri';
+        copyLinks.addEventListener('click', async () => {
+            const visible = getVisibleProblems();
+            const text = problemsToLinksText(visible);
+            if (!text) {
+                addLog('Nimic de copiat.');
+                return;
+            }
+            try {
+                await copyTextToClipboard(text);
+                addLog(`Am copiat ${visible.length} link-uri în clipboard.`);
+            } catch (err) {
+                addLog('<span style="color:#b30000;">Nu am putut copia link-urile în clipboard.</span>');
+                console.error(err);
+            }
+        });
+        groupExport.appendChild(copyLinks);
+
+        const groupScan = document.createElement('div');
+        groupScan.className = 'group';
+        groupScan.innerHTML = '<b>Scan</b>';
+
+        stopButton = document.createElement('button');
+        stopButton.textContent = 'Stop scan';
+        stopButton.addEventListener('click', () => stopScan('Oprit de utilizator'));
+        groupScan.appendChild(stopButton);
+
+        const scanNote = document.createElement('div');
+        scanNote.className = 'muted';
+        scanNote.textContent = `resume: re-rulează scriptul cu start page > 1 (curent ${config.startPage})`;
+        groupScan.appendChild(scanNote);
+
+        controlsDiv.replaceChildren(groupStatus, groupScore, groupExport, groupScan);
     }
 
     function formatDuration(ms) {
@@ -746,6 +852,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     function finishScan({ complete, reason }) {
         if (finished) return;
         finished = true;
+        if (stopButton) stopButton.disabled = true;
 
         document.body.appendChild(table);
         document.body.appendChild(listDiv);
@@ -795,9 +902,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     function initQueueFromTotalPages() {
         if (queueInitialized) return;
         if (!Number.isFinite(totalPages)) return;
-        for (let i = 2; i <= totalPages; i++) pageQueue.push(i);
+        const startAt = Math.max(1, Number.isFinite(config.startPage) ? config.startPage : 1);
+        for (let i = startAt + 1; i <= totalPages; i++) pageQueue.push(i);
         queueInitialized = true;
-        const extraWorkers = Math.max(0, Math.min(config.concurrency, totalPages) - 1);
+        const pagesToScan = Math.max(0, totalPages - startAt + 1);
+        const extraWorkers = Math.max(0, Math.min(config.concurrency, pagesToScan) - 1);
         for (let i = 0; i < extraWorkers; i++) fetchNext();
     }
 
@@ -806,10 +915,12 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         inFlight++;
         updateProgress(inFlight);
         const xhr = new XMLHttpRequest();
+        activeRequests.add(xhr);
         let finalized = false;
         const finalize = () => {
             if (finalized) return;
             finalized = true;
+            activeRequests.delete(xhr);
             inFlight = Math.max(0, inFlight - 1);
             updateProgress(inFlight);
         };
@@ -856,7 +967,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             pageEl.innerHTML = responseText;
             const cards = pageEl.querySelectorAll('div.card.mb-3');
 
-            if (pageIndex === 1) {
+            if (pageIndex === firstFetchedPageIndex) {
                 if (pageSize == null && cards.length > 0) {
                     pageSize = cards.length;
                     addLog(`Page size detectată automat: ${pageSize}.`);
@@ -870,7 +981,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 }
                 updateProgress(inFlight);
                 if (!queueInitialized && Number.isFinite(totalPages)) {
-                    addLog(`Total detectat: ${totalProblems} probleme · ${totalPages} pagini · pageSize=${pageSize} · concurență=${config.concurrency}.`);
+                    addLog(`Total detectat: ${totalProblems} probleme · ${totalPages} pagini · pageSize=${pageSize} · startPage=${config.startPage} · concurență=${config.concurrency}.`);
                     initQueueFromTotalPages();
                 }
             }
@@ -1008,7 +1119,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             const scoreWarning = scoreUnavailable ? ' (punctaj indisponibil pentru toate)' : '';
             const parseFailSuffix = parseFailCount > 0 ? ` · parseFail=${parseFailCount}` : '';
             addLog(`Pagina ${pageIndex}: rezolvate ${pageSolved}, încercate ${pageTried}, neîncercate ${pageUnattempted} (total ${totalCount})${scoreWarning}${parseFailSuffix}.`);
-            if (pageIndex === 1 && totalCount > 0 && scoreUnavailable) {
+            if (pageIndex === firstFetchedPageIndex && totalCount > 0 && scoreUnavailable) {
                 addLog(`<span style="color:#b35c00;"><b>Atenție:</b> nu pare să fie disponibil punctajul tău pe această listă. Verifică dacă ești autentificat pe pbinfo.ro.</span>`);
             }
 
@@ -1018,6 +1129,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 return;
             }
             schedule(() => fetchPage(pageIndex + 1, 0));
+        };
+        xhr.onabort = () => {
+            finalize();
+            if (stopRequested || finished) return;
+            finishScan({ complete: false, reason: `Request abort la pagina ${pageIndex}` });
         };
         xhr.ontimeout = () => {
             finalize();
@@ -1031,6 +1147,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         };
         xhr.onerror = () => {
             finalize();
+            if (stopRequested || finished) return;
             if (retryCount < maxRetriesPerPage) {
                 const delay = 1000 * (retryCount + 1);
                 addLog(`Eroare de rețea la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
@@ -1042,6 +1159,6 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         xhr.send();
     }
 
-    fetchPage(1, 0);
+    fetchPage(config.startPage, 0);
 })();
 }

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -35,24 +35,32 @@ function selectScoreFromCandidates(candidates) {
   const userHints = ['obtinut', 'realizat', 'utilizator', 'user', 'tau'];
   const maxHints = ['maxim', 'max'];
 
-  const isMaxCand = (c) =>
-    maxHints.some(
-      (h) => normalizeForMatch(c.tooltip).includes(h) || normalizeForMatch(c.text).includes(h)
-    );
-  const isUserCand = (c) =>
-    userHints.some(
-      (h) => normalizeForMatch(c.tooltip).includes(h) || normalizeForMatch(c.text).includes(h)
-    );
+  const normTooltip = (c) => normalizeForMatch(c.tooltip);
+  const normText = (c) => normalizeForMatch(c.text);
+  const normAll = (c) => `${normTooltip(c)} ${normText(c)}`;
+
+  const isUserCand = (c) => userHints.some((h) => normAll(c).includes(h));
+
+  // Important: pbinfo sometimes uses "Punctajul tău maxim" to mean the user's best score,
+  // not the maximum possible points. Treat "maxim" as max-points only when it's not in a user context.
+  const isMaxPointsCand = (c) => {
+    if (isUserCand(c)) return false;
+    const all = normAll(c);
+    if (all.includes('punctaj maxim') || all.includes('scor maxim')) return true;
+    const hasMaxHint = maxHints.some((h) => all.includes(h));
+    const hasScoreWord = all.includes('punctaj') || all.includes('scor') || all.includes('score');
+    return hasMaxHint && hasScoreWord;
+  };
 
   let maxScore = null;
   for (const c of candidates) {
-    if (isMaxCand(c) && Number.isFinite(c.value)) {
+    if (isMaxPointsCand(c) && Number.isFinite(c.value)) {
       maxScore = c.value;
       break;
     }
   }
 
-  const nonMaxCandidates = candidates.filter((c) => !isMaxCand(c));
+  const nonMaxCandidates = candidates.filter((c) => !isMaxPointsCand(c));
   if (nonMaxCandidates.length === 0) {
     return { userScore: null, maxScore };
   }
@@ -129,7 +137,17 @@ function buildScoreCandidatesFromCard(card) {
       const text = normalizeSpace(el.textContent);
       const parsed = parseScoreText(text);
       if (!parsed) continue;
-      if (!/\bp\b/i.test(text) && !parsed.hasRatio) continue;
+      const tt = normalizeForMatch(getTooltipText(el));
+      const withinFooter = Boolean(el.closest?.('div.card-footer'));
+      const withinSolveButton = (() => {
+        const btn = el.closest?.('a.btn');
+        if (!btn) return false;
+        const btnText = normalizeForMatch(btn.textContent);
+        return btnText.includes('rezolv');
+      })();
+      const hasScoreTooltip = tt.includes('punctaj') || tt.includes('scor') || tt.includes('score');
+      const looksLikeScoreText = /\bp\b/i.test(text) || parsed.hasRatio;
+      if (!looksLikeScoreText && !hasScoreTooltip && !withinFooter && !withinSolveButton) continue;
       candidates.push({
         el,
         tooltip: getTooltipText(el),

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -244,6 +244,32 @@ function problemsToLinksText(problems) {
     .join('\n');
 }
 
+function problemsToIdsText(problems) {
+  return (Array.isArray(problems) ? problems : [])
+    .map((p) => (p && Number.isFinite(p.id) ? String(p.id) : ''))
+    .filter(Boolean)
+    .join('\n');
+}
+
+function escapeMarkdownLinkText(text) {
+  const t = normalizeSpace(text);
+  return t.replaceAll('\\', '\\\\').replaceAll('[', '\\[').replaceAll(']', '\\]');
+}
+
+function problemsToMarkdownText(problems) {
+  return (Array.isArray(problems) ? problems : [])
+    .map((p) => {
+      const id = Number.isFinite(p?.id) ? p.id : null;
+      const name = escapeMarkdownLinkText(p?.name || '');
+      const link = typeof p?.link === 'string' ? p.link.trim() : '';
+      if (!link) return '';
+      const label = id != null ? `#${id} - ${name}` : name;
+      return `- [${label}](<${link}>)`;
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
 if (typeof window === 'undefined' || typeof document === 'undefined') {
   if (typeof module !== 'undefined') {
     module.exports = {
@@ -260,6 +286,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       buildPageUrl,
       problemsToCsv,
       problemsToLinksText,
+      problemsToIdsText,
+      problemsToMarkdownText,
     };
   }
 } else {
@@ -468,7 +496,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     const stats = { solved: 0, tried: 0, unattempted: 0, total: 0, pages: 0 };
     let finished = false;
     let stopRequested = false;
+    let paused = false;
     let stopButton = null;
+    let pauseButton = null;
     const activeRequests = new Set();
 
     const debugEnabled = Boolean(window.PBINFO_GET_UNSOLVED_DEBUG);
@@ -699,6 +729,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     function stopScan(reason) {
       if (finished) return;
       stopRequested = true;
+      paused = false;
+      if (pauseButton) {
+        pauseButton.disabled = true;
+        pauseButton.textContent = 'Pauză';
+      }
       if (stopButton) {
         stopButton.disabled = true;
         stopButton.textContent = 'Oprit';
@@ -710,6 +745,17 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         } catch {}
       }
       finishScan({ complete: false, reason: reason || 'Oprit de utilizator' });
+    }
+
+    function togglePause() {
+      if (finished || stopRequested) return;
+      paused = !paused;
+      if (pauseButton) pauseButton.textContent = paused ? 'Continuă' : 'Pauză';
+      addLog(paused ? '<b>Scanare pusă pe pauză.</b>' : '<b>Scanare reluată.</b>');
+      updateProgress(inFlight);
+      if (!paused) {
+        for (let i = 0; i < config.concurrency; i++) schedule(kick);
+      }
     }
 
     function setupControls() {
@@ -838,9 +884,52 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       });
       groupExport.appendChild(copyLinks);
 
+      const copyIds = document.createElement('button');
+      copyIds.textContent = 'Copiază ID-uri';
+      copyIds.addEventListener('click', async () => {
+        const visible = getVisibleProblems();
+        const text = problemsToIdsText(visible);
+        if (!text) {
+          addLog('Nimic de copiat.');
+          return;
+        }
+        try {
+          await copyTextToClipboard(text);
+          addLog(`Am copiat ${visible.length} ID-uri în clipboard.`);
+        } catch (err) {
+          addLog('<span style="color:#b30000;">Nu am putut copia ID-urile în clipboard.</span>');
+          console.error(err);
+        }
+      });
+      groupExport.appendChild(copyIds);
+
+      const copyMarkdown = document.createElement('button');
+      copyMarkdown.textContent = 'Copiază Markdown';
+      copyMarkdown.addEventListener('click', async () => {
+        const visible = getVisibleProblems();
+        const text = problemsToMarkdownText(visible);
+        if (!text) {
+          addLog('Nimic de copiat.');
+          return;
+        }
+        try {
+          await copyTextToClipboard(text);
+          addLog(`Am copiat ${visible.length} rânduri Markdown în clipboard.`);
+        } catch (err) {
+          addLog('<span style="color:#b30000;">Nu am putut copia Markdown în clipboard.</span>');
+          console.error(err);
+        }
+      });
+      groupExport.appendChild(copyMarkdown);
+
       const groupScan = document.createElement('div');
       groupScan.className = 'group';
       groupScan.innerHTML = '<b>Scan</b>';
+
+      pauseButton = document.createElement('button');
+      pauseButton.textContent = 'Pauză';
+      pauseButton.addEventListener('click', togglePause);
+      groupScan.appendChild(pauseButton);
 
       stopButton = document.createElement('button');
       stopButton.textContent = 'Stop scan';
@@ -849,7 +938,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
       const scanNote = document.createElement('div');
       scanNote.className = 'muted';
-      scanNote.textContent = `resume: re-rulează scriptul cu start page > 1 (curent ${config.startPage})`;
+      scanNote.textContent = `resume: start page > 1 (curent ${config.startPage}) · maxPages=${config.maxPages}`;
       groupScan.appendChild(scanNote);
 
       controlsDiv.replaceChildren(groupStatus, groupScore, groupExport, groupScan);
@@ -876,10 +965,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       const etaMs =
         Number.isFinite(totalPages) && speed > 0 ? ((totalPages - pagesDone) / speed) * 1000 : null;
       const etaText = etaMs != null ? ` · ETA ~${formatDuration(etaMs)}` : '';
+      const pauseText = paused ? ' · pauză' : '';
       const inflightText = inFlight > 0 ? ` · în lucru ${inFlight}` : '';
       progressDiv.textContent = `Progres: pagini ${pagesText}, probleme ${probsText} · timp ${formatDuration(
         elapsedMs
-      )}${etaText}${inflightText}`;
+      )}${etaText}${pauseText}${inflightText}`;
     }
 
     setupControls();
@@ -961,6 +1051,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     function finishScan({ complete, reason }) {
       if (finished) return;
       finished = true;
+      if (pauseButton) pauseButton.disabled = true;
       if (stopButton) stopButton.disabled = true;
 
       document.body.appendChild(table);
@@ -987,12 +1078,59 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     // Fetch pages (optional concurrency)
     const maxRetriesPerPage = config.maxRetriesPerPage;
     const pageQueue = [];
+    const deferredPageRequests = new Map();
+    let nextSequentialPage = null;
     let queueInitialized = false;
     let inFlight = 0;
 
     function schedule(fn) {
       if (config.delayMs > 0) setTimeout(fn, config.delayMs);
       else fn();
+    }
+
+    function deferPage(pageIndex, retryCount) {
+      if (!Number.isFinite(pageIndex)) return;
+      const idx = Math.trunc(pageIndex);
+      const existing = deferredPageRequests.get(idx);
+      const rc = Math.max(0, Number.isFinite(retryCount) ? Math.trunc(retryCount) : 0);
+      if (existing == null || rc > existing) deferredPageRequests.set(idx, rc);
+    }
+
+    function takeDeferred() {
+      if (deferredPageRequests.size === 0) return null;
+      let bestPage = null;
+      let bestRetry = 0;
+      for (const [pageIndex, retryCount] of deferredPageRequests.entries()) {
+        if (bestPage == null || pageIndex < bestPage) {
+          bestPage = pageIndex;
+          bestRetry = retryCount;
+        }
+      }
+      if (bestPage == null) return null;
+      deferredPageRequests.delete(bestPage);
+      return { pageIndex: bestPage, retryCount: bestRetry };
+    }
+
+    function kick() {
+      if (finished || paused) return;
+      if (inFlight >= config.concurrency) return;
+
+      const deferred = takeDeferred();
+      if (deferred) {
+        fetchPage(deferred.pageIndex, deferred.retryCount);
+        return;
+      }
+
+      if (queueInitialized) {
+        fetchNext();
+        return;
+      }
+
+      if (nextSequentialPage != null) {
+        const p = nextSequentialPage;
+        nextSequentialPage = null;
+        fetchPage(p, 0);
+      }
     }
 
     function maybeFinish() {
@@ -1003,7 +1141,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     }
 
     function fetchNext() {
-      if (finished) return;
+      if (finished || paused) return;
+      if (inFlight >= config.concurrency) return;
       const next = pageQueue.shift();
       if (next == null) {
         maybeFinish();
@@ -1016,15 +1155,41 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       if (queueInitialized) return;
       if (!Number.isFinite(totalPages)) return;
       const startAt = Math.max(1, Number.isFinite(config.startPage) ? config.startPage : 1);
-      for (let i = startAt + 1; i <= totalPages; i++) pageQueue.push(i);
+      const cap = Number.isFinite(config.maxPages) ? config.maxPages : null;
+      const cappedTotalPages = cap != null ? Math.min(totalPages, cap) : totalPages;
+      if (cappedTotalPages < totalPages) {
+        addLog(
+          `<span style="color:#b35c00;"><b>Atenție:</b> totalPages=${totalPages} depășește maxPages=${cap}. Voi scana doar primele ${cappedTotalPages} pagini.</span>`
+        );
+        totalPages = cappedTotalPages;
+      }
+
+      for (let i = startAt + 1; i <= cappedTotalPages; i++) pageQueue.push(i);
       queueInitialized = true;
-      const pagesToScan = Math.max(0, totalPages - startAt + 1);
+      const pagesToScan = Math.max(0, cappedTotalPages - startAt + 1);
       const extraWorkers = Math.max(0, Math.min(config.concurrency, pagesToScan) - 1);
-      for (let i = 0; i < extraWorkers; i++) fetchNext();
+      for (let i = 0; i < extraWorkers; i++) kick();
     }
 
     function fetchPage(pageIndex, retryCount = 0) {
-      if (finished) return;
+      if (finished || stopRequested) return;
+      if (paused) {
+        deferPage(pageIndex, retryCount);
+        return;
+      }
+      if (Number.isFinite(config.maxPages) && pageIndex > config.maxPages) {
+        pageQueue.length = 0;
+        deferredPageRequests.clear();
+        finishScan({
+          complete: false,
+          reason: `Limita maxPages=${config.maxPages} a fost atinsă (pagina ${pageIndex}).`,
+        });
+        return;
+      }
+      if (inFlight >= config.concurrency) {
+        deferPage(pageIndex, retryCount);
+        return;
+      }
       inFlight++;
       updateProgress(inFlight);
       const xhr = new XMLHttpRequest();
@@ -1258,10 +1423,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
         finalize();
         if (queueInitialized) {
-          schedule(fetchNext);
+          schedule(kick);
           return;
         }
-        schedule(() => fetchPage(pageIndex + 1, 0));
+        nextSequentialPage = pageIndex + 1;
+        schedule(kick);
       };
       xhr.onabort = () => {
         finalize();

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -1015,7 +1015,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     let totalPages = scanMode === 'id-range' ? config.idRange.endId : null;
     let startedAt = Date.now();
 
-    const stats = { solved: 0, tried: 0, unattempted: 0, total: 0, pages: 0, missing: 0 };
+    const stats = {
+      solved: 0,
+      tried: 0,
+      unattempted: 0,
+      total: 0,
+      pages: 0,
+      missing: 0,
+      forbidden: 0,
+    };
     let finished = false;
     let scanEnd = null;
     let restoringState = false;
@@ -1808,9 +1816,10 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           totalIds != null && totalIds > 0 && speed > 0 ? ((totalIds - done) / speed) * 1000 : null;
         const etaText = etaMs != null ? ` · ETA ~${formatDuration(etaMs)}` : '';
         const missingText = stats.missing > 0 ? ` · 404 ${stats.missing}` : '';
+        const forbiddenText = stats.forbidden > 0 ? ` · 403 ${stats.forbidden}` : '';
         progressDiv.textContent = `Progres: ID-uri ${idsText}, probleme ${stats.total} (găsite)${missingText} · timp ${formatDuration(
           elapsedMs
-        )}${etaText}${pauseText}${inflightText}${startText}`;
+        )}${etaText}${pauseText}${inflightText}${startText}${forbiddenText}`;
         return;
       }
 
@@ -1991,9 +2000,16 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       renderResults();
 
       const unitLabel = scanMode === 'id-range' ? 'ID-uri' : 'pagini';
-      const missingSuffix =
-        scanMode === 'id-range' && stats.missing > 0 ? `, 404 ${stats.missing}` : '';
-      const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, ${unitLabel} ${stats.pages}${missingSuffix}).`;
+      const idRangeSuffixParts =
+        scanMode === 'id-range'
+          ? [
+              stats.missing > 0 ? `404 ${stats.missing}` : null,
+              stats.forbidden > 0 ? `403 ${stats.forbidden}` : null,
+            ].filter(Boolean)
+          : [];
+      const idRangeSuffix =
+        idRangeSuffixParts.length > 0 ? `, ${idRangeSuffixParts.join(', ')}` : '';
+      const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, ${unitLabel} ${stats.pages}${idRangeSuffix}).`;
       addLog(summary);
 
       const unsolvedCount = allProblems.filter((p) => p.status !== 'solved').length;
@@ -2354,6 +2370,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           stats.total = Number.isFinite(state.stats.total) ? state.stats.total : 0;
           stats.pages = Number.isFinite(state.stats.pages) ? state.stats.pages : 0;
           stats.missing = Number.isFinite(state.stats.missing) ? state.stats.missing : 0;
+          stats.forbidden = Number.isFinite(state.stats.forbidden) ? state.stats.forbidden : 0;
         }
 
         allProblems.length = 0;
@@ -2671,8 +2688,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       }
 
       if (stats.pages > 0 && stats.pages % idRangeLogEvery === 0) {
+        const forbiddenSuffix = stats.forbidden > 0 ? ` · 403 ${stats.forbidden}` : '';
         addLog(
-          `ID ${problemId}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}.`
+          `ID ${problemId}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}${forbiddenSuffix}.`
         );
       }
 
@@ -2878,10 +2896,24 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             return;
           }
           if (stats.pages > 0 && stats.pages % idRangeLogEvery === 0) {
+            const forbiddenSuffix = stats.forbidden > 0 ? ` · 403 ${stats.forbidden}` : '';
             addLog(
-              `ID ${pageIndex}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}.`
+              `ID ${pageIndex}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}${forbiddenSuffix}.`
             );
           }
+          finalize();
+          schedule(kick);
+          return;
+        }
+
+        if (scanMode === 'id-range' && (xhr.status === 401 || xhr.status === 403)) {
+          stats.pages++;
+          stats.forbidden++;
+          idRangeConsecutiveMissing = 0;
+          maybeAutoSave('id');
+          addLog(
+            `<span style="color:#b35c00;"><b>Atenție:</b> ${unitLabel} a răspuns cu status ${xhr.status} (Acces interzis). Sar peste și continui scanarea.</span>`
+          );
           finalize();
           schedule(kick);
           return;
@@ -2999,8 +3031,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           }
 
           if (stats.pages > 0 && stats.pages % idRangeLogEvery === 0) {
+            const forbiddenSuffix = stats.forbidden > 0 ? ` · 403 ${stats.forbidden}` : '';
             addLog(
-              `ID ${pageIndex}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}.`
+              `ID ${pageIndex}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}${forbiddenSuffix}.`
             );
           }
 

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -357,19 +357,54 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     const style = document.createElement('style');
     style.innerHTML = `
-        :root { font-family: Arial, sans-serif; }
-        a:hover{cursor:pointer;}
-        td{border:1px solid black;padding:0.25em 0.4em;vertical-align:top;}
-        table{border-collapse:collapse;}
+        :root{
+            font-family: Arial, sans-serif;
+            --bg: #ffffff;
+            --text: #111827;
+            --muted: #6b7280;
+            --border: #d1d5db;
+            --panel: #f9fafb;
+            --btn-hover: #eef2ff;
+            --table-header-bg: #f3f4f6;
+            --table-row-alt: #fafafa;
+            --table-row-hover: #eef2ff;
+            --link: #1d4ed8;
+        }
+        @media (prefers-color-scheme: dark){
+            :root{
+                --bg: #0b0f14;
+                --text: #e5e7eb;
+                --muted: #9ca3af;
+                --border: #243041;
+                --panel: #121826;
+                --btn-hover: #1b2a44;
+                --table-header-bg: #121826;
+                --table-row-alt: #0f1522;
+                --table-row-hover: #1b2a44;
+                --link: #93c5fd;
+            }
+        }
+        body{margin:0;padding:0.9rem;background:var(--bg);color:var(--text);}
+        a{color:var(--link);text-decoration:none;}
+        a:hover{cursor:pointer;text-decoration:underline;}
+        #log span{line-height:1.35;}
         #controls{margin:0.75em 0 0.5em;display:flex;flex-wrap:wrap;gap:0.75em;align-items:flex-end;}
-        #controls .group{display:flex;flex-direction:column;gap:0.25em;min-width:12em;}
+        #controls .group{display:flex;flex-direction:column;gap:0.25em;min-width:12em;padding:0.5em;border:1px solid var(--border);border-radius:0.5em;background:var(--panel);}
         #controls label{display:flex;gap:0.4em;align-items:center;user-select:none;}
         #controls input[type="number"]{width:8em;}
-        #controls button{padding:0.3em 0.6em;}
-        #progress{margin:0.4em 0 0.2em;color:#444;}
-        #summary{margin:0.5em 0;color:#333;}
+        #controls button{padding:0.35em 0.65em;border:1px solid var(--border);border-radius:0.45em;background:transparent;color:var(--text);}
+        #controls button:hover{background:var(--btn-hover);}
+        #controls button:disabled{opacity:0.55;cursor:not-allowed;}
+        #progress{margin:0.4em 0 0.2em;color:var(--muted);}
+        #summary{margin:0.5em 0;color:var(--text);}
         .pill{display:inline-block;padding:0.1em 0.4em;border-radius:0.4em;color:white;}
-        .muted{color:#666;}
+        .muted{color:var(--muted);}
+        table{border-collapse:collapse;margin-top:0.75em;}
+        th,td{border:1px solid var(--border);padding:0.25em 0.4em;vertical-align:top;}
+        thead th{position:sticky;top:0;background:var(--table-header-bg);z-index:2;}
+        thead th a{display:inline-flex;gap:0.25em;align-items:center;}
+        tbody tr:nth-child(even){background:var(--table-row-alt);}
+        tbody tr:hover{background:var(--table-row-hover);}
     `;
     document.head.appendChild(style);
 
@@ -824,28 +859,53 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             if (s === 'tried') return 'f0ad4e';
             return '6c757d';
         }
-        table.innerHTML = `<tr style="font-weight:bold;">
-            <td style="min-width:5em;user-select:none;"><a onclick="sortTable('cnt')">Contor ${sortSymbol('cnt')}</a></td>
-            <td style="min-width:10em;user-select:none;"><a onclick="sortTable('id')">Nume ${sortSymbol('id')}</a></td>
-            <td style="min-width:5em;user-select:none;"><a onclick="sortTable('score')">Punctaj ${sortSymbol('score')}</a></td>
-            <td style="min-width:7.5em;user-select:none;"><a onclick="sortTable('status')">Stare ${sortSymbol('status')}</a></td>
-            <td style="min-width:6.5em;user-select:none;"><a onclick="sortTable('difficulty')">Dificultate ${sortSymbol('difficulty')}</a></td>
-            <td style="min-width:13em;user-select:none;"><a onclick="sortTable('postedBy_name')">Postată de ${sortSymbol('postedBy_name')}</a></td>
-            <td style="min-width:10em;user-select:none;"><a onclick="sortTable('author')">Autor ${sortSymbol('author')}</a></td>
-            <td style="min-width:10em;user-select:none;"><a onclick="sortTable('source')">Sursa problemei ${sortSymbol('source')}</a></td>
-        </tr>`;
+
+        table.replaceChildren();
+        const thead = document.createElement('thead');
+        const tbody = document.createElement('tbody');
+        table.appendChild(thead);
+        table.appendChild(tbody);
+
+        const headerDefs = [
+            { key: 'cnt', label: 'Contor', minWidth: '5em' },
+            { key: 'id', label: 'Nume', minWidth: '10em' },
+            { key: 'score', label: 'Punctaj', minWidth: '5em' },
+            { key: 'status', label: 'Stare', minWidth: '7.5em' },
+            { key: 'difficulty', label: 'Dificultate', minWidth: '6.5em' },
+            { key: 'postedBy_name', label: 'Postată de', minWidth: '13em' },
+            { key: 'author', label: 'Autor', minWidth: '10em' },
+            { key: 'source', label: 'Sursa problemei', minWidth: '10em' },
+        ];
+
+        const headRow = document.createElement('tr');
+        for (const h of headerDefs) {
+            const th = document.createElement('th');
+            th.style.minWidth = h.minWidth;
+            th.style.userSelect = 'none';
+            const a = document.createElement('a');
+            a.href = '#';
+            a.innerHTML = `${h.label} ${sortSymbol(h.key)}`;
+            a.addEventListener('click', (e) => {
+                e.preventDefault();
+                sortTable(h.key);
+            });
+            th.appendChild(a);
+            headRow.appendChild(th);
+        }
+        thead.appendChild(headRow);
+
         const list = Array.isArray(visibleProblems) ? visibleProblems : getVisibleProblems();
         list.forEach((p, i) => {
             const row = document.createElement('tr');
             row.innerHTML = `<td>${i + 1}.</td>
-                <td><a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a></td>
+                <td><a href="${p.link}" target="_blank" rel="noopener noreferrer">#${p.id} - ${p.name}</a></td>
                 <td>${p.userScore != null && Number.isFinite(p.userScore) ? `${p.userScore}p` : '-'}</td>
                 <td><span class="pill" style="background-color:#${statusColor(p.status)};">${statusLabel(p.status)}</span></td>
                 <td><span class="pill" style="background-color:#${difficultyColor(p.difficulty)};">${numberToDifficulty(p.difficulty)}</span></td>
-                <td>${p.postedBy_link ? `<a target="_blank" href="${p.postedBy_link}"><img style="vertical-align:middle;width:1.1em;" src="${p.postedBy_img}"> ${p.postedBy_name}</a>` : ''}</td>
+                <td>${p.postedBy_link ? `<a target="_blank" rel="noopener noreferrer" href="${p.postedBy_link}"><img style="vertical-align:middle;width:1.1em;" src="${p.postedBy_img}"> ${p.postedBy_name}</a>` : ''}</td>
                 <td>${p.author}</td>
                 <td>${p.source}</td>`;
-            table.appendChild(row);
+            tbody.appendChild(row);
         });
     }
 

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -66,6 +66,15 @@ function selectScoreFromCandidates(candidates) {
         return { userScore: null, maxScore };
     }
 
+    // Heuristic:
+    // When pbinfo can't (or doesn't) show the user's score, it may still show the maximum points
+    // as a generic "Punctaj 100p". If that's the only score-like value we see and it's not
+    // explicitly "obtinut" (or a ratio like 0/100), treat it as max points, not as a solved score.
+    const looksLikeUserScore = isUserCand(best) || best.hasRatio;
+    if (!looksLikeUserScore && candidates.length === 1 && best.value === 100 && maxScore == null) {
+        return { userScore: null, maxScore: 100 };
+    }
+
     if (best.max != null && Number.isFinite(best.max)) maxScore = best.max;
     return { userScore: best.value, maxScore };
 }
@@ -384,6 +393,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             } else {
                 const unknownSuffix = unknownScoreCount > 0 ? ` (punctaj indisponibil pentru ${unknownScoreCount})` : '';
                 addLog(`Pagina ${pageIndex} are ${solvedCount}/${totalCount} probleme rezolvate.${unknownSuffix}`);
+                if (pageIndex === 1 && totalCount > 0 && unknownScoreCount === totalCount) {
+                    addLog(`<span style="color:#b35c00;"><b>Atenție:</b> nu pare să fie disponibil punctajul tău pe această listă. Verifică dacă ești autentificat pe pbinfo.ro.</span>`);
+                }
                 fetchPage(pageIndex + 1, 0);
             }
         };

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -388,11 +388,93 @@ function problemsToMarkdownText(problems) {
       const name = escapeMarkdownLinkText(p?.name || '');
       const link = typeof p?.link === 'string' ? p.link.trim() : '';
       if (!link) return '';
-      const label = id != null ? `#${id} - ${name}` : name;
+      const label = id != null ? (name ? `#${id} - ${name}` : `#${id}`) : name;
       return `- [${label}](<${link}>)`;
     })
     .filter(Boolean)
     .join('\n');
+}
+
+function serializeProblemForSnapshot(p, level) {
+  const base = {
+    id: p?.id,
+    name: p?.name,
+    link: p?.link,
+    difficulty: p?.difficulty,
+    status: p?.status,
+    userScore: Number.isFinite(p?.userScore) ? p.userScore : null,
+    maxScore: Number.isFinite(p?.maxScore) ? p.maxScore : null,
+  };
+  if (level === 'minimal') return base;
+  return {
+    ...base,
+    postedBy_link: p?.postedBy_link,
+    postedBy_name: p?.postedBy_name,
+    postedBy_img: p?.postedBy_img,
+    author: p?.author,
+    source: p?.source,
+  };
+}
+
+function computeResumeFromStateSnapshot(snapshot) {
+  const candidates = [];
+  const q = Array.isArray(snapshot?.pageQueue) ? snapshot.pageQueue : [];
+  if (q.length > 0 && Number.isFinite(q[0])) candidates.push(q[0]);
+  const d = Array.isArray(snapshot?.deferred) ? snapshot.deferred : [];
+  for (const entry of d) {
+    const pageIndex = Array.isArray(entry) ? entry[0] : entry?.pageIndex;
+    if (Number.isFinite(pageIndex)) candidates.push(pageIndex);
+  }
+  const f = Array.isArray(snapshot?.inFlightPages) ? snapshot.inFlightPages : [];
+  for (const pageIndex of f) if (Number.isFinite(pageIndex)) candidates.push(pageIndex);
+  if (Number.isFinite(snapshot?.nextSequentialPage)) candidates.push(snapshot.nextSequentialPage);
+  const min = candidates.length > 0 ? Math.min(...candidates) : null;
+  return Number.isFinite(min) ? min : null;
+}
+
+function restoreProblemsFromSnapshot(snapshot) {
+  const allProblems = [];
+  const seenProblemIds = new Set();
+
+  const problems = Array.isArray(snapshot?.problems) ? snapshot.problems : [];
+  for (const p of problems) {
+    const id = Number.isFinite(p?.id) ? p.id : NaN;
+    if (!Number.isFinite(id)) continue;
+    const userScore = Number.isFinite(p?.userScore) ? p.userScore : null;
+    const maxScore = Number.isFinite(p?.maxScore) ? p.maxScore : 100;
+    const status =
+      p?.status === 'solved' || p?.status === 'tried' || p?.status === 'unattempted'
+        ? p.status
+        : classifyProblemStatus({ userScore, maxScore });
+    const scoreKnown = userScore != null && Number.isFinite(userScore);
+    allProblems.push({
+      cnt: allProblems.length + 1,
+      id,
+      name: typeof p?.name === 'string' ? p.name : '',
+      link: typeof p?.link === 'string' ? p.link : '',
+      difficulty: Number.isFinite(p?.difficulty) ? p.difficulty : 3,
+      score: scoreKnown ? userScore : -1,
+      scoreKnown,
+      userScore,
+      maxScore,
+      status,
+      postedBy_link: typeof p?.postedBy_link === 'string' ? p.postedBy_link : '',
+      postedBy_name: typeof p?.postedBy_name === 'string' ? p.postedBy_name : '',
+      postedBy_img: typeof p?.postedBy_img === 'string' ? p.postedBy_img : '',
+      author: typeof p?.author === 'string' ? p.author : '',
+      source: typeof p?.source === 'string' ? p.source : '',
+    });
+    seenProblemIds.add(id);
+  }
+
+  if (Array.isArray(snapshot?.seenProblemIds) && snapshot.seenProblemIds.length > 0) {
+    for (const n of snapshot.seenProblemIds) {
+      const id = parseInt(n, 10);
+      if (Number.isFinite(id)) seenProblemIds.add(id);
+    }
+  }
+
+  return { allProblems, seenProblemIds };
 }
 
 if (typeof window === 'undefined' || typeof document === 'undefined') {
@@ -415,6 +497,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       problemsToLinksText,
       problemsToIdsText,
       problemsToMarkdownText,
+      serializeProblemForSnapshot,
+      computeResumeFromStateSnapshot,
+      restoreProblemsFromSnapshot,
       isLikelyPbinfoNotFoundHtml,
       isLikelyPbinfoBlockedHtml,
     };
@@ -456,6 +541,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       return {
         full: `${STORAGE_NAMESPACE}:state:v${STATE_STORAGE_VERSION}:${h}`,
         minimal: `${STORAGE_NAMESPACE}:state-min:v${STATE_STORAGE_VERSION}:${h}`,
+        index: `${STORAGE_NAMESPACE}:state-index:v${STATE_STORAGE_VERSION}:${h}`,
+        itemPrefix: `${STORAGE_NAMESPACE}:state-item:v${STATE_STORAGE_VERSION}:${h}:`,
       };
     }
 
@@ -479,10 +566,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       } catch {}
     }
 
-    function applyThemePreference(value) {
+    function applyThemePreference(value, targetEl) {
+      const el = targetEl && targetEl.setAttribute ? targetEl : document.documentElement;
       const v = value === 'light' || value === 'dark' || value === 'system' ? value : 'system';
-      if (v === 'system') document.documentElement.removeAttribute('data-theme');
-      else document.documentElement.setAttribute('data-theme', v);
+      if (v === 'system') el.removeAttribute('data-theme');
+      else el.setAttribute('data-theme', v);
       persistThemePreference(v);
       return v;
     }
@@ -502,6 +590,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             ? Number(window.PBINFO_GET_UNSOLVED_ID_MISSING_STOP)
             : 0
         ),
+        scoreBatch: {
+          enabled: window.PBINFO_GET_UNSOLVED_ID_SCORE_BATCH !== false,
+          size: Math.max(
+            1,
+            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_ID_SCORE_BATCH_SIZE))
+              ? Number(window.PBINFO_GET_UNSOLVED_ID_SCORE_BATCH_SIZE)
+              : 200
+          ),
+        },
       },
       pagination: {
         mode: window.PBINFO_GET_UNSOLVED_PAGINATION_MODE || 'offset',
@@ -738,19 +835,52 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     const firstFetchedPageIndex = config.startPage;
     let themePreference = loadThemePreference();
 
-    // wipe the page and setup UI
-    document.head.innerHTML = '';
-    document.body.innerHTML = '';
-    themePreference = applyThemePreference(themePreference);
+    const overlayEnabled = window.PBINFO_GET_UNSOLVED_OVERLAY === true;
+    const UI_ROOT_ID = 'pbinfo-get-unsolved-root';
+    const UI_STYLE_ID = 'pbinfo-get-unsolved-style';
+    const UI_ID_LOG = 'pbinfo-get-unsolved-log';
+    const UI_ID_PROGRESS = 'pbinfo-get-unsolved-progress';
+    const UI_ID_CONTROLS = 'pbinfo-get-unsolved-controls';
+    const UI_ID_SUMMARY = 'pbinfo-get-unsolved-summary';
+
+    // setup UI root (overlay or destructive)
+    try {
+      document.getElementById(UI_ROOT_ID)?.remove();
+    } catch {}
+    if (!overlayEnabled) {
+      document.head.innerHTML = '';
+      document.body.innerHTML = '';
+      document.body.style.margin = '0';
+      document.body.style.padding = '0';
+    }
+    const appRoot = document.createElement('div');
+    appRoot.id = UI_ROOT_ID;
+    if (overlayEnabled) {
+      appRoot.style.position = 'fixed';
+      appRoot.style.top = '0';
+      appRoot.style.left = '0';
+      appRoot.style.right = '0';
+      appRoot.style.bottom = '0';
+      appRoot.style.zIndex = '2147483647';
+      appRoot.style.overflow = 'auto';
+      appRoot.style.boxShadow = '0 0 0 1px rgba(0,0,0,0.15)';
+    }
+    document.body.appendChild(appRoot);
+    themePreference = applyThemePreference(themePreference, appRoot);
 
     const title = document.createElement('h2');
     title.style.display = 'block';
-    title.innerHTML = '<span style="color: red"> pbinfo-get-unsolved-enhanced.js</span>.';
-    document.body.appendChild(title);
+    const titleSpan = document.createElement('span');
+    titleSpan.style.color = 'red';
+    titleSpan.textContent = 'pbinfo-get-unsolved-enhanced.js';
+    title.appendChild(titleSpan);
+    title.appendChild(document.createTextNode('.'));
+    appRoot.appendChild(title);
 
     const style = document.createElement('style');
+    style.id = UI_STYLE_ID;
     style.innerHTML = `
-        :root{
+        #${UI_ROOT_ID}{
             font-family: Arial, sans-serif;
             --bg: #ffffff;
             --text: #111827;
@@ -762,9 +892,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             --table-row-alt: #fafafa;
             --table-row-hover: #eef2ff;
             --link: #1d4ed8;
+            color-scheme: light dark;
+            background: var(--bg);
+            color: var(--text);
+            padding: 0.9rem;
+            box-sizing: border-box;
+            min-height: 100vh;
         }
         @media (prefers-color-scheme: dark){
-            :root:not([data-theme]){
+            #${UI_ROOT_ID}:not([data-theme]){
                 --bg: #0b0f14;
                 --text: #e5e7eb;
                 --muted: #9ca3af;
@@ -777,10 +913,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 --link: #93c5fd;
             }
         }
-        :root{ color-scheme: light dark; }
-        :root[data-theme="light"]{ color-scheme: light; }
-        :root[data-theme="dark"]{ color-scheme: dark; }
-        :root[data-theme="dark"]{
+        #${UI_ROOT_ID}[data-theme="light"]{ color-scheme: light; }
+        #${UI_ROOT_ID}[data-theme="dark"]{ color-scheme: dark; }
+        #${UI_ROOT_ID}[data-theme="dark"]{
             --bg: #0b0f14;
             --text: #e5e7eb;
             --muted: #9ca3af;
@@ -792,35 +927,37 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             --table-row-hover: #1b2a44;
             --link: #93c5fd;
         }
-        body{margin:0;padding:0.9rem;background:var(--bg);color:var(--text);}
-        a{color:var(--link);text-decoration:none;}
-        a:hover{cursor:pointer;text-decoration:underline;}
-        #log span{line-height:1.35;}
-        #controls{margin:0.75em 0 0.5em;display:flex;flex-wrap:wrap;gap:0.75em;align-items:flex-end;}
-        #controls .group{display:flex;flex-direction:column;gap:0.25em;min-width:12em;padding:0.5em;border:1px solid var(--border);border-radius:0.5em;background:var(--panel);}
-        #controls label{display:flex;gap:0.4em;align-items:center;user-select:none;}
-        #controls input[type="checkbox"]{accent-color:var(--link);}
-        #controls input[type="number"]{width:8em;border:1px solid var(--border);border-radius:0.45em;padding:0.2em 0.35em;background:var(--bg);color:var(--text);}
-        #controls select{width:12em;border:1px solid var(--border);border-radius:0.45em;padding:0.25em 0.35em;background:var(--bg);color:var(--text);}
-        #controls button{padding:0.35em 0.65em;border:1px solid var(--border);border-radius:0.45em;background:transparent;color:var(--text);}
-        #controls button:hover{background:var(--btn-hover);}
-        #controls button:disabled{opacity:0.55;cursor:not-allowed;}
-        #progress{margin:0.4em 0 0.2em;color:var(--muted);}
-        #summary{margin:0.5em 0;color:var(--text);}
-        .pill{display:inline-block;padding:0.1em 0.4em;border-radius:0.4em;color:white;}
-        .muted{color:var(--muted);}
-        table{border-collapse:collapse;margin-top:0.75em;}
-        th,td{border:1px solid var(--border);padding:0.25em 0.4em;vertical-align:top;}
-        thead th{position:sticky;top:0;background:var(--table-header-bg);z-index:2;}
-        thead th a{display:inline-flex;gap:0.25em;align-items:center;}
-        tbody tr:nth-child(even){background:var(--table-row-alt);}
-        tbody tr:hover{background:var(--table-row-hover);}
+        #${UI_ROOT_ID} a{color:var(--link);text-decoration:none;}
+        #${UI_ROOT_ID} a:hover{cursor:pointer;text-decoration:underline;}
+        #${UI_ROOT_ID} #${UI_ID_LOG} span{line-height:1.35;}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS}{margin:0.75em 0 0.5em;display:flex;flex-wrap:wrap;gap:0.75em;align-items:flex-end;}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS} .group{display:flex;flex-direction:column;gap:0.25em;min-width:12em;padding:0.5em;border:1px solid var(--border);border-radius:0.5em;background:var(--panel);}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS} label{display:flex;gap:0.4em;align-items:center;user-select:none;}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS} input[type="checkbox"]{accent-color:var(--link);}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS} input[type="number"]{width:8em;border:1px solid var(--border);border-radius:0.45em;padding:0.2em 0.35em;background:var(--bg);color:var(--text);}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS} select{width:12em;border:1px solid var(--border);border-radius:0.45em;padding:0.25em 0.35em;background:var(--bg);color:var(--text);}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS} button{padding:0.35em 0.65em;border:1px solid var(--border);border-radius:0.45em;background:transparent;color:var(--text);}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS} button:hover{background:var(--btn-hover);}
+        #${UI_ROOT_ID} #${UI_ID_CONTROLS} button:disabled{opacity:0.55;cursor:not-allowed;}
+        #${UI_ROOT_ID} #${UI_ID_PROGRESS}{margin:0.4em 0 0.2em;color:var(--muted);}
+        #${UI_ROOT_ID} #${UI_ID_SUMMARY}{margin:0.5em 0;color:var(--text);}
+        #${UI_ROOT_ID} .pill{display:inline-block;padding:0.1em 0.4em;border-radius:0.4em;color:white;}
+        #${UI_ROOT_ID} .muted{color:var(--muted);}
+        #${UI_ROOT_ID} table{border-collapse:collapse;margin-top:0.75em;}
+        #${UI_ROOT_ID} th, #${UI_ROOT_ID} td{border:1px solid var(--border);padding:0.25em 0.4em;vertical-align:top;}
+        #${UI_ROOT_ID} thead th{position:sticky;top:0;background:var(--table-header-bg);z-index:2;}
+        #${UI_ROOT_ID} thead th a{display:inline-flex;gap:0.25em;align-items:center;}
+        #${UI_ROOT_ID} tbody tr:nth-child(even){background:var(--table-row-alt);}
+        #${UI_ROOT_ID} tbody tr:hover{background:var(--table-row-hover);}
     `;
+    try {
+      document.getElementById(UI_STYLE_ID)?.remove();
+    } catch {}
     document.head.appendChild(style);
 
     const logDiv = document.createElement('div');
-    logDiv.id = 'log';
-    document.body.appendChild(logDiv);
+    logDiv.id = UI_ID_LOG;
+    appRoot.appendChild(logDiv);
 
     function addLog(msg) {
       const d = new Date();
@@ -836,7 +973,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         msg;
       span.style.display = 'block';
       logDiv.appendChild(span);
-      window.scroll(0, logDiv.scrollHeight);
+      if (overlayEnabled) {
+        appRoot.scrollTop = appRoot.scrollHeight;
+      } else {
+        window.scroll(0, document.body.scrollHeight);
+      }
     }
 
     if (scanMode === 'id-range') {
@@ -852,16 +993,16 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     }
 
     const progressDiv = document.createElement('div');
-    progressDiv.id = 'progress';
-    document.body.appendChild(progressDiv);
+    progressDiv.id = UI_ID_PROGRESS;
+    appRoot.appendChild(progressDiv);
 
     const controlsDiv = document.createElement('div');
-    controlsDiv.id = 'controls';
-    document.body.appendChild(controlsDiv);
+    controlsDiv.id = UI_ID_CONTROLS;
+    appRoot.appendChild(controlsDiv);
 
     const summaryDiv = document.createElement('div');
-    summaryDiv.id = 'summary';
-    document.body.appendChild(summaryDiv);
+    summaryDiv.id = UI_ID_SUMMARY;
+    appRoot.appendChild(summaryDiv);
 
     let pageSize = config.pageSize;
     let totalProblems = null;
@@ -997,8 +1138,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     table.style.maxWidth = '1050px';
 
     function ensureResultsAttached() {
-      if (!table.isConnected) document.body.appendChild(table);
-      if (!listDiv.isConnected) document.body.appendChild(listDiv);
+      if (!table.isConnected) appRoot.appendChild(table);
+      if (!listDiv.isConnected) appRoot.appendChild(listDiv);
     }
 
     function quickSort(arr, left, right, key) {
@@ -1095,7 +1236,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           a.href = p.link;
           a.target = '_blank';
           a.rel = 'noopener noreferrer';
-          a.textContent = `#${p.id} - ${p.name}`;
+          a.textContent = p.name ? `#${p.id} - ${p.name}` : `#${p.id}`;
           li.appendChild(a);
           ul.appendChild(li);
         }
@@ -1154,13 +1295,46 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       }, 150);
     }
 
+    const liveRenderConfig = {
+      enabled: window.PBINFO_GET_UNSOLVED_LIVE_RENDER === true,
+      everyPages: Math.max(
+        1,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_LIVE_RENDER_EVERY_PAGES))
+          ? Number(window.PBINFO_GET_UNSOLVED_LIVE_RENDER_EVERY_PAGES)
+          : 2
+      ),
+      minMs: Math.max(
+        0,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_LIVE_RENDER_MIN_MS))
+          ? Number(window.PBINFO_GET_UNSOLVED_LIVE_RENDER_MIN_MS)
+          : 750
+      ),
+    };
+    let lastLiveRenderAt = 0;
+    let lastLiveRenderPages = 0;
+
+    function maybeLiveRender() {
+      if (!liveRenderConfig.enabled) return;
+      if (finished || stopRequested || restoringState) return;
+      if (allProblems.length === 0) return;
+
+      const now = Date.now();
+      if (stats.pages - lastLiveRenderPages < liveRenderConfig.everyPages) return;
+      if (now - lastLiveRenderAt < liveRenderConfig.minMs) return;
+
+      lastLiveRenderAt = now;
+      lastLiveRenderPages = stats.pages;
+      ensureResultsAttached();
+      requestRenderResults();
+    }
+
     function downloadText(filename, content, mime) {
       const blob = new Blob([content], { type: mime || 'text/plain;charset=utf-8' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
       a.download = filename;
-      document.body.appendChild(a);
+      appRoot.appendChild(a);
       a.click();
       a.remove();
       setTimeout(() => URL.revokeObjectURL(url), 1000);
@@ -1299,7 +1473,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       }
       themeSelect.value = themePreference;
       themeSelect.addEventListener('change', () => {
-        themePreference = applyThemePreference(themeSelect.value);
+        themePreference = applyThemePreference(themeSelect.value, appRoot);
         themeSelect.value = themePreference;
       });
       themeLabel.appendChild(themeSelect);
@@ -1403,19 +1577,30 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       groupSession.className = 'group';
       groupSession.innerHTML = '<b>Stare (local)</b>';
 
+      const stateSelectLabel = document.createElement('label');
+      stateSelectLabel.textContent = 'Stare';
+      const stateSelect = document.createElement('select');
+      stateSelectLabel.appendChild(stateSelect);
+      groupSession.appendChild(stateSelectLabel);
+
       const saveStateBtn = document.createElement('button');
-      saveStateBtn.textContent = 'Salvează';
+      saveStateBtn.textContent = 'Snapshot';
       saveStateBtn.addEventListener('click', () => {
-        const res = saveScanState({ mode: 'full', reason: 'manual' });
+        const label = prompt('Etichetă snapshot (opțional):', '');
+        if (label === null) return;
+        // update "latest" state too (for quick restore)
+        saveScanState({ mode: 'minimal', reason: 'manual', silent: true });
+        const res = saveSnapshotItem({
+          mode: 'full',
+          label: normalizeSpace(label),
+          reason: 'manual',
+        });
         if (!res.ok) {
-          addLog('<span style="color:#b30000;">Nu am putut salva starea.</span>');
+          addLog('<span style="color:#b30000;">Nu am putut salva snapshot-ul.</span>');
+          refreshSessionInfo();
           return;
         }
-        const note =
-          res.kind === 'full'
-            ? ' (salvat complet)'
-            : ' (salvat compact; posibilă limită de spațiu în localStorage)';
-        addLog(`Stare salvată${note}.`);
+        addLog(`Snapshot salvat (${res.storageLevel}).`);
         refreshSessionInfo();
       });
       groupSession.appendChild(saveStateBtn);
@@ -1435,15 +1620,27 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           );
           return;
         }
-        const ok = confirm('Încarci starea salvată? Rezultatele curente vor fi înlocuite.');
+        const ok = confirm('Încarci starea selectată? Rezultatele curente vor fi înlocuite.');
         if (!ok) return;
-        const loaded = loadSavedStateForLink();
-        if (!loaded) {
-          addLog('Nu există stare salvată pentru acest link.');
-          refreshSessionInfo();
-          return;
+        const selected = normalizeSpace(stateSelect.value);
+        if (selected.startsWith('snapshot:')) {
+          const id = selected.slice('snapshot:'.length);
+          const state = loadSnapshotItem(id);
+          if (!state) {
+            addLog('Snapshot inexistent (probabil șters).');
+            refreshSessionInfo();
+            return;
+          }
+          restoreFromSavedState(state, state.storageLevel === 'full' ? 'full' : 'minimal');
+        } else {
+          const loaded = loadSavedStateForLink();
+          if (!loaded) {
+            addLog('Nu există stare salvată pentru acest link.');
+            refreshSessionInfo();
+            return;
+          }
+          restoreFromSavedState(loaded.state, loaded.kind);
         }
-        restoreFromSavedState(loaded.state, loaded.kind);
         addLog('Stare încărcată.');
         refreshSessionInfo();
       });
@@ -1452,10 +1649,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       const clearStateBtn = document.createElement('button');
       clearStateBtn.textContent = 'Șterge';
       clearStateBtn.addEventListener('click', () => {
-        const ok = confirm('Ștergi starea salvată pentru acest link?');
+        const selected = normalizeSpace(stateSelect.value);
+        const ok = confirm(
+          selected.startsWith('snapshot:')
+            ? 'Ștergi snapshot-ul selectat?'
+            : 'Ștergi starea salvată (autosave) pentru acest link?'
+        );
         if (!ok) return;
-        clearSavedStateForLink();
-        addLog('Stare ștearsă.');
+        if (selected.startsWith('snapshot:')) {
+          const id = selected.slice('snapshot:'.length);
+          deleteSnapshotItem(id);
+          addLog('Snapshot șters.');
+        } else {
+          clearSavedStateForLink();
+          addLog('Stare ștearsă.');
+        }
         refreshSessionInfo();
       });
       groupSession.appendChild(clearStateBtn);
@@ -1465,23 +1673,73 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       groupSession.appendChild(sessionInfo);
 
       function refreshSessionInfo() {
-        const existing = loadSavedStateForLink();
-        if (!existing) {
+        const selectedBefore = normalizeSpace(stateSelect.value);
+        stateSelect.replaceChildren();
+
+        const latest = loadSavedStateForLink();
+        const snapshots = loadSnapshotIndexForLink();
+
+        const options = [];
+        if (latest) {
+          const savedAt = latest.state?.savedAt ? formatDateTime(latest.state.savedAt) : '-';
+          const level =
+            latest.kind === 'full'
+              ? 'complet'
+              : latest.state?.storageLevel === 'progress'
+                ? 'progres'
+                : 'compact';
+          options.push({
+            value: 'autosave',
+            label: `Autosave (${level}) · ${savedAt}`,
+            state: latest.state,
+            kind: latest.kind,
+          });
+        }
+        for (const s of snapshots) {
+          const savedAt = s.savedAt != null ? formatDateTime(s.savedAt) : '-';
+          const level =
+            s.storageLevel === 'full'
+              ? 'complet'
+              : s.storageLevel === 'progress'
+                ? 'progres'
+                : 'compact';
+          const lbl = normalizeSpace(s.label);
+          options.push({
+            value: `snapshot:${s.id}`,
+            label: `Snapshot (${level}) · ${savedAt}${lbl ? ` · ${lbl}` : ''}`,
+            state: null,
+            kind: s.storageLevel === 'full' ? 'full' : 'minimal',
+          });
+        }
+
+        if (options.length === 0) {
+          const opt = document.createElement('option');
+          opt.value = '';
+          opt.textContent = '— fără stări salvate —';
+          stateSelect.appendChild(opt);
+          stateSelect.disabled = true;
           loadStateBtn.disabled = true;
           clearStateBtn.disabled = true;
           sessionInfo.textContent = 'Nicio stare salvată.';
           return;
         }
+
+        stateSelect.disabled = false;
+        for (const o of options) {
+          const opt = document.createElement('option');
+          opt.value = o.value;
+          opt.textContent = o.label;
+          stateSelect.appendChild(opt);
+        }
+
+        const prefer = options.some((o) => o.value === selectedBefore)
+          ? selectedBefore
+          : options[0].value;
+        stateSelect.value = prefer;
+
         loadStateBtn.disabled = false;
         clearStateBtn.disabled = false;
-        const savedAt = existing.state?.savedAt ? formatDateTime(existing.state.savedAt) : '-';
-        const level =
-          existing.kind === 'full'
-            ? 'complet'
-            : existing.state?.storageLevel === 'progress'
-              ? 'progres'
-              : 'compact';
-        sessionInfo.textContent = `Salvat (${level}) la ${savedAt}.`;
+        sessionInfo.textContent = `Stări salvate: ${options.length}.`;
       }
 
       const groupScan = document.createElement('div');
@@ -1654,7 +1912,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         nameA.href = p.link;
         nameA.target = '_blank';
         nameA.rel = 'noopener noreferrer';
-        nameA.textContent = `#${p.id} - ${p.name}`;
+        nameA.textContent = p.name ? `#${p.id} - ${p.name}` : `#${p.id}`;
         tdName.appendChild(nameA);
         row.appendChild(tdName);
 
@@ -1763,6 +2021,10 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         ? Number(window.PBINFO_GET_UNSOLVED_ID_LOG_EVERY)
         : 200
     );
+    const idRangeScoreCache = new Map();
+    const idRangeScoreBatchInFlight = new Set();
+    const idRangeScoreBatchFailed = new Set();
+    let idRangeWarnedAboutScoreBatch = false;
 
     const autosaveConfig = {
       enabled: window.PBINFO_GET_UNSOLVED_AUTOSAVE !== false,
@@ -1777,6 +2039,14 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_AUTOSAVE_MS))
           ? Number(window.PBINFO_GET_UNSOLVED_AUTOSAVE_MS)
           : 120000
+      ),
+    };
+    const snapshotConfig = {
+      maxEntries: Math.max(
+        1,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_SNAPSHOTS_MAX))
+          ? Number(window.PBINFO_GET_UNSOLVED_SNAPSHOTS_MAX)
+          : 8
       ),
     };
     let lastAutosaveAt = 0;
@@ -1807,6 +2077,130 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       } catch {}
     }
 
+    function snapshotItemKey(id) {
+      const key = normalizeSpace(id);
+      return key ? `${stateKeys.itemPrefix}${key}` : null;
+    }
+
+    function normalizeSnapshotIndex(index) {
+      const raw = Array.isArray(index) ? index : [];
+      const out = [];
+      for (const item of raw) {
+        const id = normalizeSpace(item?.id);
+        if (!id) continue;
+        const savedAt = Number(item?.savedAt);
+        const storageLevel =
+          item?.storageLevel === 'full' ||
+          item?.storageLevel === 'minimal' ||
+          item?.storageLevel === 'progress'
+            ? item.storageLevel
+            : 'minimal';
+        const label = typeof item?.label === 'string' ? item.label : '';
+        out.push({ id, savedAt: Number.isFinite(savedAt) ? savedAt : null, storageLevel, label });
+      }
+      out.sort((a, b) => (b.savedAt || 0) - (a.savedAt || 0));
+      return out;
+    }
+
+    function loadSnapshotIndexForLink() {
+      try {
+        const v = safeJsonParse(localStorage.getItem(stateKeys.index));
+        return normalizeSnapshotIndex(v);
+      } catch {
+        return [];
+      }
+    }
+
+    function writeSnapshotIndexForLink(index) {
+      try {
+        localStorage.setItem(stateKeys.index, JSON.stringify(normalizeSnapshotIndex(index)));
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    function loadSnapshotItem(id) {
+      const key = snapshotItemKey(id);
+      if (!key) return null;
+      try {
+        const v = safeJsonParse(localStorage.getItem(key));
+        return v && v.pageLink === pageLink ? v : null;
+      } catch {
+        return null;
+      }
+    }
+
+    function deleteSnapshotItem(id) {
+      const key = snapshotItemKey(id);
+      if (!key) return false;
+      try {
+        localStorage.removeItem(key);
+        const idx = loadSnapshotIndexForLink().filter((x) => x.id !== id);
+        writeSnapshotIndexForLink(idx);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    function pruneSnapshotIndex(index) {
+      const max = Number.isFinite(snapshotConfig.maxEntries) ? snapshotConfig.maxEntries : 8;
+      const list = normalizeSnapshotIndex(index);
+      const pruned = [];
+      for (const entry of list) {
+        const key = snapshotItemKey(entry.id);
+        if (!key) continue;
+        try {
+          if (localStorage.getItem(key) == null) continue;
+        } catch {}
+        pruned.push(entry);
+        if (pruned.length >= max) break;
+      }
+      const keep = new Set(pruned.map((x) => x.id));
+      for (const entry of list) {
+        if (keep.has(entry.id)) continue;
+        const key = snapshotItemKey(entry.id);
+        if (!key) continue;
+        try {
+          localStorage.removeItem(key);
+        } catch {}
+      }
+      return pruned;
+    }
+
+    function saveSnapshotItem({ mode, label, reason } = {}) {
+      const id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+      const key = snapshotItemKey(id);
+      if (!key) return { ok: false, id: null, storageLevel: null };
+
+      const desired = mode === 'minimal' || mode === 'progress' ? mode : 'full';
+      const levels = desired === 'full' ? ['full', 'minimal', 'progress'] : ['minimal', 'progress'];
+
+      for (const level of levels) {
+        try {
+          const snap = buildStateSnapshot(level, reason || 'snapshot');
+          if (label) snap.label = String(label);
+          localStorage.setItem(key, JSON.stringify(snap));
+
+          const idx = pruneSnapshotIndex([
+            { id, savedAt: snap.savedAt, storageLevel: snap.storageLevel, label: snap.label || '' },
+            ...loadSnapshotIndexForLink(),
+          ]);
+          if (!writeSnapshotIndexForLink(idx)) {
+            localStorage.removeItem(key);
+            return { ok: false, id: null, storageLevel: null };
+          }
+          return { ok: true, id, storageLevel: snap.storageLevel };
+        } catch {}
+      }
+
+      try {
+        localStorage.removeItem(key);
+      } catch {}
+      return { ok: false, id: null, storageLevel: null };
+    }
+
     function serializeFilters() {
       return {
         statuses: Array.from(filterState.statuses),
@@ -1818,44 +2212,6 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     function serializeSorted() {
       return { ...sorted };
-    }
-
-    function serializeProblem(p, level) {
-      const base = {
-        id: p?.id,
-        name: p?.name,
-        link: p?.link,
-        difficulty: p?.difficulty,
-        status: p?.status,
-        userScore: Number.isFinite(p?.userScore) ? p.userScore : null,
-        maxScore: Number.isFinite(p?.maxScore) ? p.maxScore : null,
-      };
-      if (level === 'minimal') return base;
-      return {
-        ...base,
-        postedBy_link: p?.postedBy_link,
-        postedBy_name: p?.postedBy_name,
-        postedBy_img: p?.postedBy_img,
-        author: p?.author,
-        source: p?.source,
-      };
-    }
-
-    function computeResumeFromStateSnapshot(snapshot) {
-      const candidates = [];
-      const q = Array.isArray(snapshot?.pageQueue) ? snapshot.pageQueue : [];
-      if (q.length > 0 && Number.isFinite(q[0])) candidates.push(q[0]);
-      const d = Array.isArray(snapshot?.deferred) ? snapshot.deferred : [];
-      for (const entry of d) {
-        const pageIndex = Array.isArray(entry) ? entry[0] : entry?.pageIndex;
-        if (Number.isFinite(pageIndex)) candidates.push(pageIndex);
-      }
-      const f = Array.isArray(snapshot?.inFlightPages) ? snapshot.inFlightPages : [];
-      for (const pageIndex of f) if (Number.isFinite(pageIndex)) candidates.push(pageIndex);
-      if (Number.isFinite(snapshot?.nextSequentialPage))
-        candidates.push(snapshot.nextSequentialPage);
-      const min = candidates.length > 0 ? Math.min(...candidates) : null;
-      return Number.isFinite(min) ? min : null;
     }
 
     function buildStateSnapshot(level, reason) {
@@ -1894,7 +2250,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         return snapshot;
       }
 
-      snapshot.problems = allProblems.map((p) => serializeProblem(p, level));
+      snapshot.problems = allProblems.map((p) => serializeProblemForSnapshot(p, level));
       snapshot.seenProblemIds = Array.from(seenProblemIds);
       return snapshot;
     }
@@ -1966,6 +2322,12 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           if (Number.isFinite(state.idRange.endId)) config.idRange.endId = state.idRange.endId;
           if (Number.isFinite(state.idRange.stopAfterMissing))
             config.idRange.stopAfterMissing = state.idRange.stopAfterMissing;
+          if (state.idRange.scoreBatch && typeof state.idRange.scoreBatch === 'object') {
+            if (typeof state.idRange.scoreBatch.enabled === 'boolean')
+              config.idRange.scoreBatch.enabled = state.idRange.scoreBatch.enabled;
+            if (Number.isFinite(state.idRange.scoreBatch.size))
+              config.idRange.scoreBatch.size = state.idRange.scoreBatch.size;
+          }
         }
 
         if (Number.isFinite(state.scanStartPage)) config.startPage = state.scanStartPage;
@@ -1991,43 +2353,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         allProblems.length = 0;
         seenProblemIds.clear();
 
-        const problems = Array.isArray(state.problems) ? state.problems : [];
-        for (const p of problems) {
-          const id = Number.isFinite(p?.id) ? p.id : NaN;
-          if (!Number.isFinite(id)) continue;
-          const userScore = Number.isFinite(p?.userScore) ? p.userScore : null;
-          const maxScore = Number.isFinite(p?.maxScore) ? p.maxScore : 100;
-          const status =
-            p?.status === 'solved' || p?.status === 'tried' || p?.status === 'unattempted'
-              ? p.status
-              : classifyProblemStatus({ userScore, maxScore });
-          const scoreKnown = userScore != null && Number.isFinite(userScore);
-          allProblems.push({
-            cnt: allProblems.length + 1,
-            id,
-            name: typeof p?.name === 'string' ? p.name : '',
-            link: typeof p?.link === 'string' ? p.link : '',
-            difficulty: Number.isFinite(p?.difficulty) ? p.difficulty : 3,
-            score: scoreKnown ? userScore : -1,
-            scoreKnown,
-            userScore,
-            maxScore,
-            status,
-            postedBy_link: typeof p?.postedBy_link === 'string' ? p.postedBy_link : '',
-            postedBy_name: typeof p?.postedBy_name === 'string' ? p.postedBy_name : '',
-            postedBy_img: typeof p?.postedBy_img === 'string' ? p.postedBy_img : '',
-            author: typeof p?.author === 'string' ? p.author : '',
-            source: typeof p?.source === 'string' ? p.source : '',
-          });
-          seenProblemIds.add(id);
-        }
-
-        if (Array.isArray(state.seenProblemIds) && state.seenProblemIds.length > 0) {
-          for (const n of state.seenProblemIds) {
-            const id = parseInt(n, 10);
-            if (Number.isFinite(id)) seenProblemIds.add(id);
-          }
-        }
+        const restored = restoreProblemsFromSnapshot(state);
+        for (const p of restored.allProblems) allProblems.push(p);
+        for (const id of restored.seenProblemIds) seenProblemIds.add(id);
 
         if (state.filters && typeof state.filters === 'object') {
           const statuses = new Set(
@@ -2132,6 +2460,222 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       else fn();
     }
 
+    function parseIdRangeScoreValue(raw) {
+      const t = normalizeSpace(raw);
+      if (!t || t === '-') return { value: null, raw: '-' };
+      const n = parseInt(t, 10);
+      return Number.isFinite(n) ? { value: n, raw: t } : { value: null, raw: t };
+    }
+
+    function idRangeScoreBatchStartForId(id) {
+      if (!Number.isFinite(id)) return null;
+      const startId = Number.isFinite(config.idRange.startId) ? config.idRange.startId : 1;
+      const size = Number.isFinite(config.idRange.scoreBatch?.size)
+        ? config.idRange.scoreBatch.size
+        : 200;
+      if (id < startId || size <= 0) return null;
+      return startId + Math.floor((id - startId) / size) * size;
+    }
+
+    function fetchIdRangeScoreBatch(batchStart, retryCount = 0) {
+      if (finished || stopRequested || restoringState) return;
+      if (!config.idRange.scoreBatch?.enabled) return;
+      if (!Number.isFinite(batchStart)) return;
+      if (idRangeScoreBatchInFlight.has(batchStart) || idRangeScoreBatchFailed.has(batchStart))
+        return;
+      if (paused) return;
+
+      const size = Number.isFinite(config.idRange.scoreBatch.size)
+        ? config.idRange.scoreBatch.size
+        : 200;
+      const endId = Number.isFinite(config.idRange.endId) ? config.idRange.endId : null;
+      if (endId == null) return;
+
+      const ids = [];
+      const batchEnd = Math.min(endId, batchStart + size - 1);
+      for (let id = batchStart; id <= batchEnd; id++) ids.push(id);
+
+      idRangeScoreBatchInFlight.add(batchStart);
+      const xhr = new XMLHttpRequest();
+      activeRequests.add(xhr);
+      let finalized = false;
+      const finalize = () => {
+        if (finalized) return;
+        finalized = true;
+        activeRequests.delete(xhr);
+        idRangeScoreBatchInFlight.delete(batchStart);
+      };
+
+      const url = new URL(
+        '/ajx-module/json-probleme-scor.php',
+        location?.origin || 'https://www.pbinfo.ro'
+      );
+      url.searchParams.set('ids', ids.join(','));
+
+      xhr.open('GET', url.toString());
+      xhr.timeout = config.timeoutMs;
+      xhr.onload = () => {
+        const responseText = xhr.responseText || xhr.response || '';
+        if (stopRequested || finished || restoringState) {
+          finalize();
+          return;
+        }
+
+        if (isLikelyPbinfoBlockedHtml(responseText)) {
+          if (retryCount < maxRetriesPerPage) {
+            const delay = 1000 * (retryCount + 1);
+            if (!idRangeWarnedAboutScoreBatch) {
+              idRangeWarnedAboutScoreBatch = true;
+              addLog(
+                '<span style="color:#b35c00;"><b>Atenție:</b> am detectat o pagină de verificare (posibil Cloudflare) la request-ul de scoruri (batch). Folosește delay mai mare / concurență mai mică.</span>'
+              );
+            }
+            finalize();
+            setTimeout(() => fetchIdRangeScoreBatch(batchStart, retryCount + 1), delay);
+            return;
+          }
+          finalize();
+          finishScan({
+            complete: false,
+            reason:
+              'Blocare detectată la fetch-ul de scoruri (batch). Încearcă delay mai mare și/sau concurență mai mică.',
+          });
+          return;
+        }
+
+        if (xhr.status !== 200) {
+          if (retryCount < maxRetriesPerPage) {
+            const delay = 1000 * (retryCount + 1);
+            finalize();
+            setTimeout(() => fetchIdRangeScoreBatch(batchStart, retryCount + 1), delay);
+            return;
+          }
+          finalize();
+          idRangeScoreBatchFailed.add(batchStart);
+          addLog(
+            `<span style="color:#b35c00;"><b>Score batch:</b> eșuat pentru ${batchStart}-${batchEnd} (status ${xhr.status}); continui fără scoruri batch.</span>`
+          );
+          schedule(kick);
+          return;
+        }
+
+        let payload = null;
+        try {
+          payload = typeof responseText === 'string' ? JSON.parse(responseText) : responseText;
+        } catch {
+          payload = null;
+        }
+
+        const data = Array.isArray(payload?.data) ? payload.data : [];
+        for (const item of data) {
+          const id = parseInt(item?.id_problema, 10);
+          if (!Number.isFinite(id)) continue;
+          const raw = item?.scor == null ? '-' : String(item.scor);
+          const parsed = parseIdRangeScoreValue(raw);
+          idRangeScoreCache.set(id, { raw: parsed.raw, value: parsed.value });
+        }
+
+        finalize();
+        schedule(kick);
+      };
+      xhr.onabort = () => {
+        finalize();
+      };
+      xhr.ontimeout = () => {
+        finalize();
+        if (stopRequested || finished || restoringState) return;
+        if (retryCount < maxRetriesPerPage) {
+          const delay = 1000 * (retryCount + 1);
+          setTimeout(() => fetchIdRangeScoreBatch(batchStart, retryCount + 1), delay);
+          return;
+        }
+        idRangeScoreBatchFailed.add(batchStart);
+        addLog(
+          `<span style="color:#b35c00;"><b>Score batch:</b> timeout pentru batch ${batchStart}-${batchEnd}; continui fără scoruri batch.</span>`
+        );
+        schedule(kick);
+      };
+      xhr.onerror = () => {
+        finalize();
+        if (stopRequested || finished || restoringState) return;
+        if (retryCount < maxRetriesPerPage) {
+          const delay = 1000 * (retryCount + 1);
+          setTimeout(() => fetchIdRangeScoreBatch(batchStart, retryCount + 1), delay);
+          return;
+        }
+        idRangeScoreBatchFailed.add(batchStart);
+        addLog(
+          `<span style="color:#b35c00;"><b>Score batch:</b> eroare rețea pentru batch ${batchStart}-${batchEnd}; continui fără scoruri batch.</span>`
+        );
+        schedule(kick);
+      };
+      xhr.send();
+    }
+
+    function getIdRangeScorePrefetchState(id) {
+      if (scanMode !== 'id-range') return { cached: null, pending: false, batchStart: null };
+      if (!config.idRange.scoreBatch?.enabled)
+        return { cached: null, pending: false, batchStart: null };
+      const cached = idRangeScoreCache.get(id) || null;
+      if (cached) return { cached, pending: false, batchStart: null };
+      const batchStart = idRangeScoreBatchStartForId(id);
+      if (batchStart == null || idRangeScoreBatchFailed.has(batchStart))
+        return { cached: null, pending: false, batchStart };
+      if (!idRangeScoreBatchInFlight.has(batchStart)) fetchIdRangeScoreBatch(batchStart, 0);
+      return { cached: null, pending: true, batchStart };
+    }
+
+    function processIdRangeFromScoreBatch(problemId, cached) {
+      const scoreValue = Number.isFinite(cached?.value) ? cached.value : null;
+      if (scoreValue == null) return false;
+
+      stats.pages++;
+      idRangeConsecutiveMissing = 0;
+
+      const userScore = scoreValue;
+      const maxScore = 100;
+      const status = userScore >= maxScore ? 'solved' : 'tried';
+
+      if (!seenProblemIds.has(problemId)) {
+        seenProblemIds.add(problemId);
+        allProblems.push({
+          cnt: allProblems.length + 1,
+          id: problemId,
+          name: '',
+          link: new URL(
+            `/probleme/${problemId}`,
+            location?.origin || 'https://www.pbinfo.ro'
+          ).toString(),
+          difficulty: 3,
+          score: userScore,
+          scoreKnown: true,
+          userScore,
+          maxScore,
+          status,
+          postedBy_link: '',
+          postedBy_name: '',
+          postedBy_img: '',
+          author: '',
+          source: '',
+        });
+
+        if (status === 'solved') stats.solved++;
+        else stats.tried++;
+        stats.total++;
+      }
+
+      if (stats.pages > 0 && stats.pages % idRangeLogEvery === 0) {
+        addLog(
+          `ID ${problemId}: progres (${stats.pages} scanate) · găsite ${stats.total} · 404 ${stats.missing}.`
+        );
+      }
+
+      maybeAutoSave('id');
+      updateProgress(inFlight);
+      maybeLiveRender();
+      return true;
+    }
+
     function deferPage(pageIndex, retryCount) {
       if (!Number.isFinite(pageIndex)) return;
       const idx = Math.trunc(pageIndex);
@@ -2230,6 +2774,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         });
         return;
       }
+
+      if (scanMode === 'id-range') {
+        const prefetch = getIdRangeScorePrefetchState(pageIndex);
+        if (prefetch.pending) {
+          deferPage(pageIndex, retryCount);
+          return;
+        }
+        if (prefetch.cached && Number.isFinite(prefetch.cached.value)) {
+          if (processIdRangeFromScoreBatch(pageIndex, prefetch.cached)) {
+            schedule(kick);
+            return;
+          }
+        }
+      }
+
       if (inFlight >= config.concurrency) {
         deferPage(pageIndex, retryCount);
         return;
@@ -2440,6 +2999,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           }
 
           maybeAutoSave('id');
+          maybeLiveRender();
           finalize();
           schedule(kick);
           return;
@@ -2633,6 +3193,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           );
         }
 
+        maybeLiveRender();
         maybeAutoSave('page');
         finalize();
         if (queueInitialized) {

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -5,255 +5,265 @@
 // category URL or the global problems list URL when prompted.
 
 function normalizeSpace(str) {
-    return (str || '').toString().replace(/\s+/g, ' ').trim();
+  return (str || '').toString().replace(/\s+/g, ' ').trim();
 }
 
 function normalizeForMatch(str) {
-    return normalizeSpace(str)
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .toLowerCase();
+  return normalizeSpace(str)
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
 }
 
 function parseScoreText(text) {
-    const t = normalizeSpace(text);
-    if (!t) return null;
-    const ratio = /(\d{1,3})\s*\/\s*(\d{1,3})/.exec(t);
-    if (ratio) {
-        return { value: parseInt(ratio[1], 10), max: parseInt(ratio[2], 10), hasRatio: true };
-    }
-    const pct = /(\d{1,3})\s*%/.exec(t);
-    if (pct) {
-        return { value: parseInt(pct[1], 10), max: 100, hasRatio: false };
-    }
-    const num = /(\d{1,3})/.exec(t);
-    if (!num) return null;
-    return { value: parseInt(num[1], 10), max: null, hasRatio: false };
+  const t = normalizeSpace(text);
+  if (!t) return null;
+  const ratio = /(\d{1,3})\s*\/\s*(\d{1,3})/.exec(t);
+  if (ratio) {
+    return { value: parseInt(ratio[1], 10), max: parseInt(ratio[2], 10), hasRatio: true };
+  }
+  const pct = /(\d{1,3})\s*%/.exec(t);
+  if (pct) {
+    return { value: parseInt(pct[1], 10), max: 100, hasRatio: false };
+  }
+  const num = /(\d{1,3})/.exec(t);
+  if (!num) return null;
+  return { value: parseInt(num[1], 10), max: null, hasRatio: false };
 }
 
 function selectScoreFromCandidates(candidates) {
-    const userHints = ['obtinut', 'realizat', 'utilizator', 'user', 'tau'];
-    const maxHints = ['maxim', 'max'];
+  const userHints = ['obtinut', 'realizat', 'utilizator', 'user', 'tau'];
+  const maxHints = ['maxim', 'max'];
 
-    const isMaxCand = (c) => maxHints.some(h => normalizeForMatch(c.tooltip).includes(h) || normalizeForMatch(c.text).includes(h));
-    const isUserCand = (c) => userHints.some(h => normalizeForMatch(c.tooltip).includes(h) || normalizeForMatch(c.text).includes(h));
+  const isMaxCand = (c) =>
+    maxHints.some(
+      (h) => normalizeForMatch(c.tooltip).includes(h) || normalizeForMatch(c.text).includes(h)
+    );
+  const isUserCand = (c) =>
+    userHints.some(
+      (h) => normalizeForMatch(c.tooltip).includes(h) || normalizeForMatch(c.text).includes(h)
+    );
 
-    let maxScore = null;
-    for (const c of candidates) {
-        if (isMaxCand(c) && Number.isFinite(c.value)) {
-            maxScore = c.value;
-            break;
-        }
+  let maxScore = null;
+  for (const c of candidates) {
+    if (isMaxCand(c) && Number.isFinite(c.value)) {
+      maxScore = c.value;
+      break;
     }
+  }
 
-    const nonMaxCandidates = candidates.filter(c => !isMaxCand(c));
-    if (nonMaxCandidates.length === 0) {
-        return { userScore: null, maxScore };
-    }
+  const nonMaxCandidates = candidates.filter((c) => !isMaxCand(c));
+  if (nonMaxCandidates.length === 0) {
+    return { userScore: null, maxScore };
+  }
 
-    const ranked = nonMaxCandidates
-        .map(c => {
-            let rank = 0;
-            if (isUserCand(c)) rank += 100;
-            if (c.hasRatio) rank += 50;
-            if (c.isLink) rank += 10;
-            return { c, rank };
-        })
-        .sort((a, b) => b.rank - a.rank);
+  const ranked = nonMaxCandidates
+    .map((c) => {
+      let rank = 0;
+      if (isUserCand(c)) rank += 100;
+      if (c.hasRatio) rank += 50;
+      if (c.isLink) rank += 10;
+      return { c, rank };
+    })
+    .sort((a, b) => b.rank - a.rank);
 
-    const best = ranked[0]?.c;
-    if (!best || !Number.isFinite(best.value)) {
-        return { userScore: null, maxScore };
-    }
+  const best = ranked[0]?.c;
+  if (!best || !Number.isFinite(best.value)) {
+    return { userScore: null, maxScore };
+  }
 
-    // Heuristic:
-    // When pbinfo can't (or doesn't) show the user's score, it may still show the maximum points
-    // as a generic "Punctaj 100p". If that's the only score-like value we see and it's not
-    // explicitly "obtinut" (or a ratio like 0/100), treat it as max points, not as a solved score.
-    const looksLikeUserScore = isUserCand(best) || best.hasRatio;
-    if (!looksLikeUserScore && candidates.length === 1 && best.value === 100 && maxScore == null) {
-        return { userScore: null, maxScore: 100 };
-    }
+  // Heuristic:
+  // When pbinfo can't (or doesn't) show the user's score, it may still show the maximum points
+  // as a generic "Punctaj 100p". If that's the only score-like value we see and it's not
+  // explicitly "obtinut" (or a ratio like 0/100), treat it as max points, not as a solved score.
+  const looksLikeUserScore = isUserCand(best) || best.hasRatio;
+  if (!looksLikeUserScore && candidates.length === 1 && best.value === 100 && maxScore == null) {
+    return { userScore: null, maxScore: 100 };
+  }
 
-    if (best.max != null && Number.isFinite(best.max)) maxScore = best.max;
-    return { userScore: best.value, maxScore };
+  if (best.max != null && Number.isFinite(best.max)) maxScore = best.max;
+  return { userScore: best.value, maxScore };
 }
 
 const tooltipAttrs = ['title', 'data-bs-title', 'data-bs-original-title', 'data-original-title'];
 function getTooltipText(el) {
-    for (const attr of tooltipAttrs) {
-        const v = el.getAttribute?.(attr);
-        if (v) return v;
-    }
-    return '';
+  for (const attr of tooltipAttrs) {
+    const v = el.getAttribute?.(attr);
+    if (v) return v;
+  }
+  return '';
 }
 
 function buildScoreCandidatesFromCard(card) {
-    const candidates = [];
+  const candidates = [];
 
-    const tooltipEls = Array.from(card.querySelectorAll('[title],[data-bs-title],[data-bs-original-title],[data-original-title]'));
-    for (const el of tooltipEls) {
-        const tooltip = normalizeForMatch(getTooltipText(el));
-        if (!tooltip) continue;
-        if (!tooltip.includes('punctaj') && !tooltip.includes('scor') && !tooltip.includes('score')) continue;
+  const tooltipEls = Array.from(
+    card.querySelectorAll('[title],[data-bs-title],[data-bs-original-title],[data-original-title]')
+  );
+  for (const el of tooltipEls) {
+    const tooltip = normalizeForMatch(getTooltipText(el));
+    if (!tooltip) continue;
+    if (!tooltip.includes('punctaj') && !tooltip.includes('scor') && !tooltip.includes('score'))
+      continue;
 
-        const text = normalizeSpace(el.textContent);
-        const parsed = parseScoreText(text);
-        if (!parsed) continue;
+    const text = normalizeSpace(el.textContent);
+    const parsed = parseScoreText(text);
+    if (!parsed) continue;
 
-        candidates.push({
-            el,
-            tooltip: getTooltipText(el),
-            text,
-            value: parsed.value,
-            max: parsed.max,
-            hasRatio: parsed.hasRatio,
-            isLink: el.tagName === 'A',
-        });
+    candidates.push({
+      el,
+      tooltip: getTooltipText(el),
+      text,
+      value: parsed.value,
+      max: parsed.max,
+      hasRatio: parsed.hasRatio,
+      isLink: el.tagName === 'A',
+    });
+  }
+
+  if (candidates.length === 0) {
+    const badgeEls = Array.from(card.querySelectorAll('span.badge, a.badge, div.badge')).filter(
+      (el) => !normalizeSpace(el.textContent).startsWith('#')
+    );
+    for (const el of badgeEls) {
+      const text = normalizeSpace(el.textContent);
+      const parsed = parseScoreText(text);
+      if (!parsed) continue;
+      if (!/\bp\b/i.test(text) && !parsed.hasRatio) continue;
+      candidates.push({
+        el,
+        tooltip: getTooltipText(el),
+        text,
+        value: parsed.value,
+        max: parsed.max,
+        hasRatio: parsed.hasRatio,
+        isLink: el.tagName === 'A',
+      });
     }
+  }
 
-    if (candidates.length === 0) {
-        const badgeEls = Array.from(card.querySelectorAll('span.badge, a.badge, div.badge'))
-            .filter(el => !normalizeSpace(el.textContent).startsWith('#'));
-        for (const el of badgeEls) {
-            const text = normalizeSpace(el.textContent);
-            const parsed = parseScoreText(text);
-            if (!parsed) continue;
-            if (!/\bp\b/i.test(text) && !parsed.hasRatio) continue;
-            candidates.push({
-                el,
-                tooltip: getTooltipText(el),
-                text,
-                value: parsed.value,
-                max: parsed.max,
-                hasRatio: parsed.hasRatio,
-                isLink: el.tagName === 'A',
-            });
-        }
-    }
-
-    return candidates;
+  return candidates;
 }
 
 function extractScoreInfoFromCard(card) {
-    const candidates = buildScoreCandidatesFromCard(card);
-    const { userScore, maxScore } = selectScoreFromCandidates(candidates);
-    return { userScore, maxScore, candidates };
+  const candidates = buildScoreCandidatesFromCard(card);
+  const { userScore, maxScore } = selectScoreFromCandidates(candidates);
+  return { userScore, maxScore, candidates };
 }
 
 function classifyProblemStatus(scoreInfo) {
-    const maxPoints = Number.isFinite(scoreInfo?.maxScore) ? scoreInfo.maxScore : 100;
-    if (scoreInfo?.userScore == null) return 'unattempted';
-    if (scoreInfo.userScore >= maxPoints) return 'solved';
-    return 'tried';
+  const maxPoints = Number.isFinite(scoreInfo?.maxScore) ? scoreInfo.maxScore : 100;
+  if (scoreInfo?.userScore == null) return 'unattempted';
+  if (scoreInfo.userScore >= maxPoints) return 'solved';
+  return 'tried';
 }
 
 function parseTotalProblems(html) {
-    const m = /class="[^"]*\bnumar_probleme\b[^"]*"[^>]*>\s*([0-9]+)\s*</i.exec(html || '');
-    if (!m) return null;
-    const n = parseInt(m[1], 10);
-    return Number.isFinite(n) ? n : null;
+  const m = /class="[^"]*\bnumar_probleme\b[^"]*"[^>]*>\s*([0-9]+)\s*</i.exec(html || '');
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  return Number.isFinite(n) ? n : null;
 }
 
 function normalizeListUrl(inputUrl, baseUrl, paginationParam = 'start') {
-    const raw = normalizeSpace(inputUrl);
-    const base = normalizeSpace(baseUrl);
-    if (!raw && !base) return null;
-    let u;
-    try {
-        u = new URL(raw || base, base || undefined);
-    } catch {
-        return null;
-    }
-    u.searchParams.delete(paginationParam);
-    return u.toString();
+  const raw = normalizeSpace(inputUrl);
+  const base = normalizeSpace(baseUrl);
+  if (!raw && !base) return null;
+  let u;
+  try {
+    u = new URL(raw || base, base || undefined);
+  } catch {
+    return null;
+  }
+  u.searchParams.delete(paginationParam);
+  return u.toString();
 }
 
 function buildPageUrl(
-    baseUrl,
-    { pageIndex, pageSize, mode = 'offset', param = 'start', pageBase = 1 }
+  baseUrl,
+  { pageIndex, pageSize, mode = 'offset', param = 'start', pageBase = 1 }
 ) {
-    if (!baseUrl) return null;
-    const u = new URL(baseUrl);
-    if (mode === 'page') {
-        const base = Number.isFinite(pageBase) ? pageBase : 1;
-        u.searchParams.set(param, String(base + (pageIndex - 1)));
-        return u.toString();
-    }
-    const size = Number.isFinite(pageSize) ? pageSize : 10;
-    u.searchParams.set(param, String(size * (pageIndex - 1)));
+  if (!baseUrl) return null;
+  const u = new URL(baseUrl);
+  if (mode === 'page') {
+    const base = Number.isFinite(pageBase) ? pageBase : 1;
+    u.searchParams.set(param, String(base + (pageIndex - 1)));
     return u.toString();
+  }
+  const size = Number.isFinite(pageSize) ? pageSize : 10;
+  u.searchParams.set(param, String(size * (pageIndex - 1)));
+  return u.toString();
 }
 
 function csvEscape(value) {
-    if (value == null) return '';
-    const s = String(value);
-    const needsQuotes = /[",\n]/.test(s);
-    const escaped = s.replace(/"/g, '""');
-    return needsQuotes ? `"${escaped}"` : escaped;
+  if (value == null) return '';
+  const s = String(value);
+  const needsQuotes = /[",\n]/.test(s);
+  const escaped = s.replace(/"/g, '""');
+  return needsQuotes ? `"${escaped}"` : escaped;
 }
 
 function problemsToCsv(problems) {
-    const headers = [
-        'id',
-        'name',
-        'status',
-        'userScore',
-        'maxScore',
-        'difficulty',
-        'postedBy',
-        'author',
-        'source',
-        'link',
-    ];
-    const rows = Array.isArray(problems)
-        ? problems.map(p => ({
-            id: p.id,
-            name: p.name,
-            status: p.status,
-            userScore: p.userScore,
-            maxScore: p.maxScore,
-            difficulty: p.difficulty,
-            postedBy: p.postedBy_name,
-            author: p.author,
-            source: p.source,
-            link: p.link,
-        }))
-        : [];
-    const lines = [headers.join(',')].concat(
-        rows.map(r => headers.map(h => csvEscape(r[h])).join(','))
-    );
-    // Add UTF-8 BOM so Excel keeps diacritics.
-    return `\ufeff${lines.join('\n')}`;
+  const headers = [
+    'id',
+    'name',
+    'status',
+    'userScore',
+    'maxScore',
+    'difficulty',
+    'postedBy',
+    'author',
+    'source',
+    'link',
+  ];
+  const rows = Array.isArray(problems)
+    ? problems.map((p) => ({
+        id: p.id,
+        name: p.name,
+        status: p.status,
+        userScore: p.userScore,
+        maxScore: p.maxScore,
+        difficulty: p.difficulty,
+        postedBy: p.postedBy_name,
+        author: p.author,
+        source: p.source,
+        link: p.link,
+      }))
+    : [];
+  const lines = [headers.join(',')].concat(
+    rows.map((r) => headers.map((h) => csvEscape(r[h])).join(','))
+  );
+  // Add UTF-8 BOM so Excel keeps diacritics.
+  return `\ufeff${lines.join('\n')}`;
 }
 
 function problemsToLinksText(problems) {
-    return (Array.isArray(problems) ? problems : [])
-        .map(p => (p && typeof p.link === 'string' ? p.link.trim() : ''))
-        .filter(Boolean)
-        .join('\n');
+  return (Array.isArray(problems) ? problems : [])
+    .map((p) => (p && typeof p.link === 'string' ? p.link.trim() : ''))
+    .filter(Boolean)
+    .join('\n');
 }
 
 if (typeof window === 'undefined' || typeof document === 'undefined') {
-    if (typeof module !== 'undefined') {
-        module.exports = {
-            normalizeSpace,
-            normalizeForMatch,
-            parseScoreText,
-            selectScoreFromCandidates,
-            getTooltipText,
-            buildScoreCandidatesFromCard,
-            extractScoreInfoFromCard,
-            classifyProblemStatus,
-            parseTotalProblems,
-            normalizeListUrl,
-            buildPageUrl,
-            problemsToCsv,
-            problemsToLinksText,
-        };
-    }
+  if (typeof module !== 'undefined') {
+    module.exports = {
+      normalizeSpace,
+      normalizeForMatch,
+      parseScoreText,
+      selectScoreFromCandidates,
+      getTooltipText,
+      buildScoreCandidatesFromCard,
+      extractScoreInfoFromCard,
+      classifyProblemStatus,
+      parseTotalProblems,
+      normalizeListUrl,
+      buildPageUrl,
+      problemsToCsv,
+      problemsToLinksText,
+    };
+  }
 } else {
-(function () {
+  (function () {
     // restore console
     var iFrame = document.createElement('iframe');
     iFrame.style.display = 'none';
@@ -262,86 +272,90 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     console.clear();
 
     const config = {
-        pagination: {
-            mode: window.PBINFO_GET_UNSOLVED_PAGINATION_MODE || 'offset',
-            param: window.PBINFO_GET_UNSOLVED_PAGE_PARAM || 'start',
-            pageBase: Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_PAGE_BASE))
-                ? Number(window.PBINFO_GET_UNSOLVED_PAGE_BASE)
-                : 1,
-        },
-        pageSize: Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_PAGE_SIZE))
-            ? Number(window.PBINFO_GET_UNSOLVED_PAGE_SIZE)
-            : null,
-        concurrency: Math.max(
-            1,
-            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_CONCURRENCY))
-                ? Number(window.PBINFO_GET_UNSOLVED_CONCURRENCY)
-                : 1
-        ),
-        delayMs: Math.max(
-            0,
-            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_DELAY_MS))
-                ? Number(window.PBINFO_GET_UNSOLVED_DELAY_MS)
-                : 0
-        ),
-        timeoutMs: Math.max(
-            1000,
-            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_TIMEOUT_MS))
-                ? Number(window.PBINFO_GET_UNSOLVED_TIMEOUT_MS)
-                : 30000
-        ),
-        maxRetriesPerPage: Math.max(
-            0,
-            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_MAX_RETRIES))
-                ? Number(window.PBINFO_GET_UNSOLVED_MAX_RETRIES)
-                : 3
-        ),
-        startPage: Math.max(
-            1,
-            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_START_PAGE))
-                ? Number(window.PBINFO_GET_UNSOLVED_START_PAGE)
-                : 1
-        ),
-        maxPages: Math.max(
-            1,
-            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_MAX_PAGES))
-                ? Number(window.PBINFO_GET_UNSOLVED_MAX_PAGES)
-                : 5000
-        ),
+      pagination: {
+        mode: window.PBINFO_GET_UNSOLVED_PAGINATION_MODE || 'offset',
+        param: window.PBINFO_GET_UNSOLVED_PAGE_PARAM || 'start',
+        pageBase: Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_PAGE_BASE))
+          ? Number(window.PBINFO_GET_UNSOLVED_PAGE_BASE)
+          : 1,
+      },
+      pageSize: Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_PAGE_SIZE))
+        ? Number(window.PBINFO_GET_UNSOLVED_PAGE_SIZE)
+        : null,
+      concurrency: Math.max(
+        1,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_CONCURRENCY))
+          ? Number(window.PBINFO_GET_UNSOLVED_CONCURRENCY)
+          : 1
+      ),
+      delayMs: Math.max(
+        0,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_DELAY_MS))
+          ? Number(window.PBINFO_GET_UNSOLVED_DELAY_MS)
+          : 0
+      ),
+      timeoutMs: Math.max(
+        1000,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_TIMEOUT_MS))
+          ? Number(window.PBINFO_GET_UNSOLVED_TIMEOUT_MS)
+          : 30000
+      ),
+      maxRetriesPerPage: Math.max(
+        0,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_MAX_RETRIES))
+          ? Number(window.PBINFO_GET_UNSOLVED_MAX_RETRIES)
+          : 3
+      ),
+      startPage: Math.max(
+        1,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_START_PAGE))
+          ? Number(window.PBINFO_GET_UNSOLVED_START_PAGE)
+          : 1
+      ),
+      maxPages: Math.max(
+        1,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_MAX_PAGES))
+          ? Number(window.PBINFO_GET_UNSOLVED_MAX_PAGES)
+          : 5000
+      ),
     };
 
     const defaultLink = location?.href || '';
     let pageLinkInput = prompt(
-        'Pune un link către lista de probleme de unde vrei să obții problemele nerezolvate.\n' +
-            'Enter = pagina curentă. Dacă folosești filtre, copiază link-ul din bara de adrese.',
-        defaultLink
+      'Pune un link către lista de probleme de unde vrei să obții problemele nerezolvate.\n' +
+        'Enter = pagina curentă. Dacă folosești filtre, copiază link-ul din bara de adrese.',
+      defaultLink
     );
     if (pageLinkInput === null) {
-        console.warn('Nu a fost furnizat niciun link. Scriptul a fost oprit.');
-        return;
+      console.warn('Nu a fost furnizat niciun link. Scriptul a fost oprit.');
+      return;
     }
     pageLinkInput = normalizeSpace(pageLinkInput);
-    const pageLink = normalizeListUrl(pageLinkInput || defaultLink, defaultLink, config.pagination.param);
+    const pageLink = normalizeListUrl(
+      pageLinkInput || defaultLink,
+      defaultLink,
+      config.pagination.param
+    );
     if (!pageLink) {
-        console.warn('Link invalid. Scriptul a fost oprit.');
-        return;
+      console.warn('Link invalid. Scriptul a fost oprit.');
+      return;
     }
 
     let startPageInput = prompt(
-        'De la ce pagină să încep scanarea?\n' +
-            '1 = de la început. Pentru resume, pune un număr mai mare.\n' +
-            'Enter = valoarea default.',
-        String(config.startPage)
+      'De la ce pagină să încep scanarea?\n' +
+        '1 = de la început. Pentru resume, pune un număr mai mare.\n' +
+        'Enter = valoarea default.',
+      String(config.startPage)
     );
     if (startPageInput === null) {
-        console.warn('Nu a fost furnizat start page. Scriptul a fost oprit.');
-        return;
+      console.warn('Nu a fost furnizat start page. Scriptul a fost oprit.');
+      return;
     }
     startPageInput = normalizeSpace(startPageInput);
     const startPage = startPageInput === '' ? config.startPage : parseInt(startPageInput, 10);
     if (!Number.isFinite(startPage) || startPage < 1) {
-        console.warn('Start page invalid. Scriptul a fost oprit.');
-        return;
+      console.warn('Start page invalid. Scriptul a fost oprit.');
+      return;
     }
     config.startPage = startPage;
     const firstFetchedPageIndex = config.startPage;
@@ -415,13 +429,20 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     document.body.appendChild(logDiv);
 
     function addLog(msg) {
-        const d = new Date();
-        const span = document.createElement('span');
-        span.innerHTML = '<b>[' + d.getHours().toString().padStart(2, '0') + ':' +
-            d.getMinutes().toString().padStart(2, '0') + ':' + d.getSeconds().toString().padStart(2, '0') + '] - </b>' + msg;
-        span.style.display = 'block';
-        logDiv.appendChild(span);
-        window.scroll(0, logDiv.scrollHeight);
+      const d = new Date();
+      const span = document.createElement('span');
+      span.innerHTML =
+        '<b>[' +
+        d.getHours().toString().padStart(2, '0') +
+        ':' +
+        d.getMinutes().toString().padStart(2, '0') +
+        ':' +
+        d.getSeconds().toString().padStart(2, '0') +
+        '] - </b>' +
+        msg;
+      span.style.display = 'block';
+      logDiv.appendChild(span);
+      window.scroll(0, logDiv.scrollHeight);
     }
 
     addLog('Link către lista de probleme: <a href="' + pageLink + '"><i>' + pageLink + '</i></a>');
@@ -452,94 +473,111 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     const debugEnabled = Boolean(window.PBINFO_GET_UNSOLVED_DEBUG);
     const debugDumpLimit = Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_DEBUG_LIMIT))
-        ? Number(window.PBINFO_GET_UNSOLVED_DEBUG_LIMIT)
-        : 20;
+      ? Number(window.PBINFO_GET_UNSOLVED_DEBUG_LIMIT)
+      : 20;
     const debugIncludeHtml = Boolean(window.PBINFO_GET_UNSOLVED_DEBUG_HTML);
     const debugIds = Array.isArray(window.PBINFO_GET_UNSOLVED_DEBUG_IDS)
-        ? new Set(window.PBINFO_GET_UNSOLVED_DEBUG_IDS.map(n => parseInt(n, 10)).filter(Number.isFinite))
-        : null;
+      ? new Set(
+          window.PBINFO_GET_UNSOLVED_DEBUG_IDS.map((n) => parseInt(n, 10)).filter(Number.isFinite)
+        )
+      : null;
     let debugDumped = 0;
 
     if (debugEnabled) {
-        addLog(`<span style="color:#b35c00;"><b>Debug:</b> activ (limită dump=${debugDumpLimit}${debugIds ? `, ids=${Array.from(debugIds).join(',')}` : ''}).</span>`);
+      addLog(
+        `<span style="color:#b35c00;"><b>Debug:</b> activ (limită dump=${debugDumpLimit}${debugIds ? `, ids=${Array.from(debugIds).join(',')}` : ''}).</span>`
+      );
     }
 
     function shouldDebugDump(id) {
-        if (!debugEnabled) return false;
-        if (debugDumped >= debugDumpLimit) return false;
-        if (debugIds && !debugIds.has(id)) return false;
-        return true;
+      if (!debugEnabled) return false;
+      if (debugDumped >= debugDumpLimit) return false;
+      if (debugIds && !debugIds.has(id)) return false;
+      return true;
     }
 
     function debugDumpCard(card, meta) {
-        debugDumped++;
+      debugDumped++;
 
-        const tooltipEls = Array.from(card.querySelectorAll('[title],[data-bs-title],[data-bs-original-title],[data-original-title]'));
-        const tooltips = tooltipEls
-            .map(el => ({
-                tag: el.tagName,
-                tooltip: getTooltipText(el),
-                text: normalizeSpace(el.textContent),
-            }))
-            .filter(x => x.tooltip || x.text);
+      const tooltipEls = Array.from(
+        card.querySelectorAll(
+          '[title],[data-bs-title],[data-bs-original-title],[data-original-title]'
+        )
+      );
+      const tooltips = tooltipEls
+        .map((el) => ({
+          tag: el.tagName,
+          tooltip: getTooltipText(el),
+          text: normalizeSpace(el.textContent),
+        }))
+        .filter((x) => x.tooltip || x.text);
 
-        const badges = Array.from(card.querySelectorAll('.badge'))
-            .map(el => normalizeSpace(el.textContent))
-            .filter(Boolean);
+      const badges = Array.from(card.querySelectorAll('.badge'))
+        .map((el) => normalizeSpace(el.textContent))
+        .filter(Boolean);
 
-        const candidates = (meta.scoreInfo?.candidates || []).map(c => ({
-            tag: c.el?.tagName,
-            tooltip: c.tooltip,
-            text: c.text,
-            value: c.value,
-            max: c.max,
-            hasRatio: c.hasRatio,
-        }));
+      const candidates = (meta.scoreInfo?.candidates || []).map((c) => ({
+        tag: c.el?.tagName,
+        tooltip: c.tooltip,
+        text: c.text,
+        value: c.value,
+        max: c.max,
+        hasRatio: c.hasRatio,
+      }));
 
-        console.log('pbinfo-get-unsolved debug:', {
-            id: meta.id,
-            name: meta.name,
-            link: meta.link,
-            scoreInfo: { userScore: meta.scoreInfo?.userScore, maxScore: meta.scoreInfo?.maxScore },
-            candidates,
-            tooltips,
-            badges,
-        });
+      console.log('pbinfo-get-unsolved debug:', {
+        id: meta.id,
+        name: meta.name,
+        link: meta.link,
+        scoreInfo: { userScore: meta.scoreInfo?.userScore, maxScore: meta.scoreInfo?.maxScore },
+        candidates,
+        tooltips,
+        badges,
+      });
 
-        if (debugIncludeHtml) {
-            console.log('pbinfo-get-unsolved debug card html:', (card.outerHTML || '').slice(0, 5000));
-        }
+      if (debugIncludeHtml) {
+        console.log('pbinfo-get-unsolved debug card html:', (card.outerHTML || '').slice(0, 5000));
+      }
     }
 
     async function copyTextToClipboard(text) {
-        const value = String(text || '');
-        if (navigator?.clipboard?.writeText) {
-            await navigator.clipboard.writeText(value);
-            return;
-        }
-        const ta = document.createElement('textarea');
-        ta.value = value;
-        ta.setAttribute('readonly', 'true');
-        ta.style.position = 'fixed';
-        ta.style.top = '-1000px';
-        ta.style.left = '-1000px';
-        document.body.appendChild(ta);
-        ta.focus();
-        ta.select();
-        const ok = document.execCommand('copy');
-        ta.remove();
-        if (!ok) throw new Error('Clipboard copy failed');
+      const value = String(text || '');
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(value);
+        return;
+      }
+      const ta = document.createElement('textarea');
+      ta.value = value;
+      ta.setAttribute('readonly', 'true');
+      ta.style.position = 'fixed';
+      ta.style.top = '-1000px';
+      ta.style.left = '-1000px';
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      const ok = document.execCommand('copy');
+      ta.remove();
+      if (!ok) throw new Error('Clipboard copy failed');
     }
 
     const allProblems = [];
     const seenProblemIds = new Set();
-    const sorted = { cnt: 1, id: 0, score: 0, status: 0, difficulty: 0, postedBy_name: 0, author: 0, source: 0 };
+    const sorted = {
+      cnt: 1,
+      id: 0,
+      score: 0,
+      status: 0,
+      difficulty: 0,
+      postedBy_name: 0,
+      author: 0,
+      source: 0,
+    };
 
     const filterState = {
-        statuses: new Set(['tried', 'unattempted']),
-        includeUnknownScore: true,
-        scoreMin: null,
-        scoreMax: null,
+      statuses: new Set(['tried', 'unattempted']),
+      includeUnknownScore: true,
+      scoreMin: null,
+      scoreMax: null,
     };
 
     const listDiv = document.createElement('div');
@@ -551,80 +589,83 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     table.style.maxWidth = '1050px';
 
     function quickSort(arr, left, right, key) {
-        let index;
-        if (arr.length > 1) {
-            index = partition(arr, left, right, key);
-            if (left < index - 1) quickSort(arr, left, index - 1, key);
-            if (index < right) quickSort(arr, index, right, key);
-        }
-        return arr;
+      let index;
+      if (arr.length > 1) {
+        index = partition(arr, left, right, key);
+        if (left < index - 1) quickSort(arr, left, index - 1, key);
+        if (index < right) quickSort(arr, index, right, key);
+      }
+      return arr;
     }
     function partition(arr, left, right, key) {
-        let pivot = arr[Math.floor((right + left) / 2)][key];
-        let i = left;
-        let j = right;
-        while (i <= j) {
-            while (arr[i][key] < pivot) i++;
-            while (arr[j][key] > pivot) j--;
-            if (i <= j) {
-                [arr[i], arr[j]] = [arr[j], arr[i]];
-                i++;
-                j--;
-            }
+      let pivot = arr[Math.floor((right + left) / 2)][key];
+      let i = left;
+      let j = right;
+      while (i <= j) {
+        while (arr[i][key] < pivot) i++;
+        while (arr[j][key] > pivot) j--;
+        if (i <= j) {
+          [arr[i], arr[j]] = [arr[j], arr[i]];
+          i++;
+          j--;
         }
-        return i;
+      }
+      return i;
     }
 
     function sortTable(type) {
-        if (sorted[type] === 0) {
-            Object.keys(sorted).forEach(k => sorted[k] = 0);
-            sorted[type] = 1;
-        } else {
-            sorted[type] *= -1;
-        }
-        quickSort(allProblems, 0, allProblems.length - 1, type);
-        if (sorted[type] === -1) allProblems.reverse();
-        renderResults();
+      if (sorted[type] === 0) {
+        Object.keys(sorted).forEach((k) => (sorted[k] = 0));
+        sorted[type] = 1;
+      } else {
+        sorted[type] *= -1;
+      }
+      quickSort(allProblems, 0, allProblems.length - 1, type);
+      if (sorted[type] === -1) allProblems.reverse();
+      renderResults();
     }
 
     window.sortTable = sortTable;
 
     function getVisibleProblems() {
-        const min = Number.isFinite(filterState.scoreMin) ? filterState.scoreMin : null;
-        const max = Number.isFinite(filterState.scoreMax) ? filterState.scoreMax : null;
-        const includeUnknown = Boolean(filterState.includeUnknownScore);
-        const statuses = filterState.statuses;
+      const min = Number.isFinite(filterState.scoreMin) ? filterState.scoreMin : null;
+      const max = Number.isFinite(filterState.scoreMax) ? filterState.scoreMax : null;
+      const includeUnknown = Boolean(filterState.includeUnknownScore);
+      const statuses = filterState.statuses;
 
-        return allProblems.filter(p => {
-            if (!statuses.has(p.status)) return false;
-            const scoreKnown = p.userScore != null && Number.isFinite(p.userScore);
-            if (!scoreKnown) return includeUnknown;
-            if (min != null && p.userScore < min) return false;
-            if (max != null && p.userScore > max) return false;
-            return true;
-        });
+      return allProblems.filter((p) => {
+        if (!statuses.has(p.status)) return false;
+        const scoreKnown = p.userScore != null && Number.isFinite(p.userScore);
+        if (!scoreKnown) return includeUnknown;
+        if (min != null && p.userScore < min) return false;
+        if (max != null && p.userScore > max) return false;
+        return true;
+      });
     }
 
     function updateSummary(visible) {
-        const shown = visible.length;
-        const total = allProblems.length;
-        const unsolved = allProblems.filter(p => p.status !== 'solved').length;
-        summaryDiv.innerHTML = `<b>Statistici:</b> scanate=${total} · nerezolvate=${unsolved} · afișate=${shown} · pagini=${stats.pages}`;
+      const shown = visible.length;
+      const total = allProblems.length;
+      const unsolved = allProblems.filter((p) => p.status !== 'solved').length;
+      summaryDiv.innerHTML = `<b>Statistici:</b> scanate=${total} · nerezolvate=${unsolved} · afișate=${shown} · pagini=${stats.pages}`;
     }
 
     function updateList(visible) {
-        const tried = visible.filter(p => p.status === 'tried');
-        const unattempted = visible.filter(p => p.status === 'unattempted');
-        const solved = visible.filter(p => p.status === 'solved');
+      const tried = visible.filter((p) => p.status === 'tried');
+      const unattempted = visible.filter((p) => p.status === 'unattempted');
+      const solved = visible.filter((p) => p.status === 'solved');
 
-        function mkList(items) {
-            if (items.length === 0) return '<span class="muted">-</span>';
-            return `<ul style="list-style:none;padding-left:0;margin:0;">${items
-                .map(p => `<li style="margin:0.15em 0;"><a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a></li>`)
-                .join('')}</ul>`;
-        }
+      function mkList(items) {
+        if (items.length === 0) return '<span class="muted">-</span>';
+        return `<ul style="list-style:none;padding-left:0;margin:0;">${items
+          .map(
+            (p) =>
+              `<li style="margin:0.15em 0;"><a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a></li>`
+          )
+          .join('')}</ul>`;
+      }
 
-        listDiv.innerHTML = `<h3>Lista (filtrată):</h3>
+      listDiv.innerHTML = `<h3>Lista (filtrată):</h3>
             <div style="margin-bottom:0.5em;">
                 Încercate: <b>${tried.length}</b> · Neîncercate: <b>${unattempted.length}</b> · Rezolvate: <b>${solved.length}</b>
             </div>
@@ -637,202 +678,208 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     }
 
     function renderResults() {
-        const visible = getVisibleProblems();
-        updateTable(visible);
-        updateSummary(visible);
-        updateList(visible);
+      const visible = getVisibleProblems();
+      updateTable(visible);
+      updateSummary(visible);
+      updateList(visible);
     }
 
     function downloadText(filename, content, mime) {
-        const blob = new Blob([content], { type: mime || 'text/plain;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = filename;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        setTimeout(() => URL.revokeObjectURL(url), 1000);
+      const blob = new Blob([content], { type: mime || 'text/plain;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
     }
 
     function stopScan(reason) {
-        if (finished) return;
-        stopRequested = true;
-        if (stopButton) {
-            stopButton.disabled = true;
-            stopButton.textContent = 'Oprit';
-        }
-        pageQueue.length = 0;
-        for (const xhr of activeRequests) {
-            try {
-                xhr.abort();
-            } catch {}
-        }
-        finishScan({ complete: false, reason: reason || 'Oprit de utilizator' });
+      if (finished) return;
+      stopRequested = true;
+      if (stopButton) {
+        stopButton.disabled = true;
+        stopButton.textContent = 'Oprit';
+      }
+      pageQueue.length = 0;
+      for (const xhr of activeRequests) {
+        try {
+          xhr.abort();
+        } catch {}
+      }
+      finishScan({ complete: false, reason: reason || 'Oprit de utilizator' });
     }
 
     function setupControls() {
-        const groupStatus = document.createElement('div');
-        groupStatus.className = 'group';
-        groupStatus.innerHTML = '<b>Stare</b>';
+      const groupStatus = document.createElement('div');
+      groupStatus.className = 'group';
+      groupStatus.innerHTML = '<b>Stare</b>';
 
-        const statuses = [
-            { key: 'solved', label: 'rezolvate' },
-            { key: 'tried', label: 'încercate' },
-            { key: 'unattempted', label: 'neîncercate' },
-        ];
+      const statuses = [
+        { key: 'solved', label: 'rezolvate' },
+        { key: 'tried', label: 'încercate' },
+        { key: 'unattempted', label: 'neîncercate' },
+      ];
 
-        for (const s of statuses) {
-            const label = document.createElement('label');
-            const input = document.createElement('input');
-            input.type = 'checkbox';
-            input.checked = filterState.statuses.has(s.key);
-            input.addEventListener('change', () => {
-                if (input.checked) filterState.statuses.add(s.key);
-                else filterState.statuses.delete(s.key);
-                renderResults();
-            });
-            label.appendChild(input);
-            label.appendChild(document.createTextNode(` ${s.label}`));
-            groupStatus.appendChild(label);
+      for (const s of statuses) {
+        const label = document.createElement('label');
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.checked = filterState.statuses.has(s.key);
+        input.addEventListener('change', () => {
+          if (input.checked) filterState.statuses.add(s.key);
+          else filterState.statuses.delete(s.key);
+          renderResults();
+        });
+        label.appendChild(input);
+        label.appendChild(document.createTextNode(` ${s.label}`));
+        groupStatus.appendChild(label);
+      }
+
+      const groupScore = document.createElement('div');
+      groupScore.className = 'group';
+      groupScore.innerHTML = '<b>Filtru punctaj</b>';
+
+      const minLabel = document.createElement('label');
+      minLabel.textContent = 'Min';
+      const minInput = document.createElement('input');
+      minInput.type = 'number';
+      minInput.min = '0';
+      minInput.placeholder = '-';
+      minInput.addEventListener('input', () => {
+        const v = Number(minInput.value);
+        filterState.scoreMin = Number.isFinite(v) && minInput.value !== '' ? v : null;
+        renderResults();
+      });
+      minLabel.appendChild(minInput);
+      groupScore.appendChild(minLabel);
+
+      const maxLabel = document.createElement('label');
+      maxLabel.textContent = 'Max';
+      const maxInput = document.createElement('input');
+      maxInput.type = 'number';
+      maxInput.min = '0';
+      maxInput.placeholder = '-';
+      maxInput.addEventListener('input', () => {
+        const v = Number(maxInput.value);
+        filterState.scoreMax = Number.isFinite(v) && maxInput.value !== '' ? v : null;
+        renderResults();
+      });
+      maxLabel.appendChild(maxInput);
+      groupScore.appendChild(maxLabel);
+
+      const unknownLabel = document.createElement('label');
+      const unknownInput = document.createElement('input');
+      unknownInput.type = 'checkbox';
+      unknownInput.checked = filterState.includeUnknownScore;
+      unknownInput.addEventListener('change', () => {
+        filterState.includeUnknownScore = unknownInput.checked;
+        renderResults();
+      });
+      unknownLabel.appendChild(unknownInput);
+      unknownLabel.appendChild(document.createTextNode(' include scor necunoscut'));
+      groupScore.appendChild(unknownLabel);
+
+      const groupExport = document.createElement('div');
+      groupExport.className = 'group';
+      groupExport.innerHTML = '<b>Export</b>';
+
+      const exportCsv = document.createElement('button');
+      exportCsv.textContent = 'CSV (filtrat)';
+      exportCsv.addEventListener('click', () => {
+        const visible = getVisibleProblems();
+        downloadText('pbinfo-problems.csv', problemsToCsv(visible), 'text/csv;charset=utf-8');
+      });
+      groupExport.appendChild(exportCsv);
+
+      const exportJson = document.createElement('button');
+      exportJson.textContent = 'JSON (filtrat)';
+      exportJson.addEventListener('click', () => {
+        const visible = getVisibleProblems();
+        const data = visible.map((p) => ({
+          id: p.id,
+          name: p.name,
+          link: p.link,
+          status: p.status,
+          userScore: p.userScore,
+          maxScore: p.maxScore,
+          difficulty: p.difficulty,
+          postedBy_name: p.postedBy_name,
+          postedBy_link: p.postedBy_link,
+          author: p.author,
+          source: p.source,
+        }));
+        downloadText(
+          'pbinfo-problems.json',
+          JSON.stringify(data, null, 2),
+          'application/json;charset=utf-8'
+        );
+      });
+      groupExport.appendChild(exportJson);
+
+      const copyLinks = document.createElement('button');
+      copyLinks.textContent = 'Copiază link-uri';
+      copyLinks.addEventListener('click', async () => {
+        const visible = getVisibleProblems();
+        const text = problemsToLinksText(visible);
+        if (!text) {
+          addLog('Nimic de copiat.');
+          return;
         }
+        try {
+          await copyTextToClipboard(text);
+          addLog(`Am copiat ${visible.length} link-uri în clipboard.`);
+        } catch (err) {
+          addLog('<span style="color:#b30000;">Nu am putut copia link-urile în clipboard.</span>');
+          console.error(err);
+        }
+      });
+      groupExport.appendChild(copyLinks);
 
-        const groupScore = document.createElement('div');
-        groupScore.className = 'group';
-        groupScore.innerHTML = '<b>Filtru punctaj</b>';
+      const groupScan = document.createElement('div');
+      groupScan.className = 'group';
+      groupScan.innerHTML = '<b>Scan</b>';
 
-        const minLabel = document.createElement('label');
-        minLabel.textContent = 'Min';
-        const minInput = document.createElement('input');
-        minInput.type = 'number';
-        minInput.min = '0';
-        minInput.placeholder = '-';
-        minInput.addEventListener('input', () => {
-            const v = Number(minInput.value);
-            filterState.scoreMin = Number.isFinite(v) && minInput.value !== '' ? v : null;
-            renderResults();
-        });
-        minLabel.appendChild(minInput);
-        groupScore.appendChild(minLabel);
+      stopButton = document.createElement('button');
+      stopButton.textContent = 'Stop scan';
+      stopButton.addEventListener('click', () => stopScan('Oprit de utilizator'));
+      groupScan.appendChild(stopButton);
 
-        const maxLabel = document.createElement('label');
-        maxLabel.textContent = 'Max';
-        const maxInput = document.createElement('input');
-        maxInput.type = 'number';
-        maxInput.min = '0';
-        maxInput.placeholder = '-';
-        maxInput.addEventListener('input', () => {
-            const v = Number(maxInput.value);
-            filterState.scoreMax = Number.isFinite(v) && maxInput.value !== '' ? v : null;
-            renderResults();
-        });
-        maxLabel.appendChild(maxInput);
-        groupScore.appendChild(maxLabel);
+      const scanNote = document.createElement('div');
+      scanNote.className = 'muted';
+      scanNote.textContent = `resume: re-rulează scriptul cu start page > 1 (curent ${config.startPage})`;
+      groupScan.appendChild(scanNote);
 
-        const unknownLabel = document.createElement('label');
-        const unknownInput = document.createElement('input');
-        unknownInput.type = 'checkbox';
-        unknownInput.checked = filterState.includeUnknownScore;
-        unknownInput.addEventListener('change', () => {
-            filterState.includeUnknownScore = unknownInput.checked;
-            renderResults();
-        });
-        unknownLabel.appendChild(unknownInput);
-        unknownLabel.appendChild(document.createTextNode(' include scor necunoscut'));
-        groupScore.appendChild(unknownLabel);
-
-        const groupExport = document.createElement('div');
-        groupExport.className = 'group';
-        groupExport.innerHTML = '<b>Export</b>';
-
-        const exportCsv = document.createElement('button');
-        exportCsv.textContent = 'CSV (filtrat)';
-        exportCsv.addEventListener('click', () => {
-            const visible = getVisibleProblems();
-            downloadText('pbinfo-problems.csv', problemsToCsv(visible), 'text/csv;charset=utf-8');
-        });
-        groupExport.appendChild(exportCsv);
-
-        const exportJson = document.createElement('button');
-        exportJson.textContent = 'JSON (filtrat)';
-        exportJson.addEventListener('click', () => {
-            const visible = getVisibleProblems();
-            const data = visible.map(p => ({
-                id: p.id,
-                name: p.name,
-                link: p.link,
-                status: p.status,
-                userScore: p.userScore,
-                maxScore: p.maxScore,
-                difficulty: p.difficulty,
-                postedBy_name: p.postedBy_name,
-                postedBy_link: p.postedBy_link,
-                author: p.author,
-                source: p.source,
-            }));
-            downloadText('pbinfo-problems.json', JSON.stringify(data, null, 2), 'application/json;charset=utf-8');
-        });
-        groupExport.appendChild(exportJson);
-
-        const copyLinks = document.createElement('button');
-        copyLinks.textContent = 'Copiază link-uri';
-        copyLinks.addEventListener('click', async () => {
-            const visible = getVisibleProblems();
-            const text = problemsToLinksText(visible);
-            if (!text) {
-                addLog('Nimic de copiat.');
-                return;
-            }
-            try {
-                await copyTextToClipboard(text);
-                addLog(`Am copiat ${visible.length} link-uri în clipboard.`);
-            } catch (err) {
-                addLog('<span style="color:#b30000;">Nu am putut copia link-urile în clipboard.</span>');
-                console.error(err);
-            }
-        });
-        groupExport.appendChild(copyLinks);
-
-        const groupScan = document.createElement('div');
-        groupScan.className = 'group';
-        groupScan.innerHTML = '<b>Scan</b>';
-
-        stopButton = document.createElement('button');
-        stopButton.textContent = 'Stop scan';
-        stopButton.addEventListener('click', () => stopScan('Oprit de utilizator'));
-        groupScan.appendChild(stopButton);
-
-        const scanNote = document.createElement('div');
-        scanNote.className = 'muted';
-        scanNote.textContent = `resume: re-rulează scriptul cu start page > 1 (curent ${config.startPage})`;
-        groupScan.appendChild(scanNote);
-
-        controlsDiv.replaceChildren(groupStatus, groupScore, groupExport, groupScan);
+      controlsDiv.replaceChildren(groupStatus, groupScore, groupExport, groupScan);
     }
 
     function formatDuration(ms) {
-        const s = Math.max(0, Math.floor(ms / 1000));
-        const h = Math.floor(s / 3600);
-        const m = Math.floor((s % 3600) / 60);
-        const ss = s % 60;
-        if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m ${String(ss).padStart(2, '0')}s`;
-        if (m > 0) return `${m}m ${String(ss).padStart(2, '0')}s`;
-        return `${ss}s`;
+      const s = Math.max(0, Math.floor(ms / 1000));
+      const h = Math.floor(s / 3600);
+      const m = Math.floor((s % 3600) / 60);
+      const ss = s % 60;
+      if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m ${String(ss).padStart(2, '0')}s`;
+      if (m > 0) return `${m}m ${String(ss).padStart(2, '0')}s`;
+      return `${ss}s`;
     }
 
     function updateProgress(inFlight) {
-        const elapsedMs = Date.now() - startedAt;
-        const pagesDone = stats.pages;
-        const pagesText = Number.isFinite(totalPages) ? `${pagesDone}/${totalPages}` : `${pagesDone}`;
-        const probsText = Number.isFinite(totalProblems) ? `${stats.total}/${totalProblems}` : `${stats.total}`;
-        const speed = elapsedMs > 0 ? pagesDone / (elapsedMs / 1000) : 0;
-        const etaMs =
-            Number.isFinite(totalPages) && speed > 0 ? ((totalPages - pagesDone) / speed) * 1000 : null;
-        const etaText = etaMs != null ? ` · ETA ~${formatDuration(etaMs)}` : '';
-        const inflightText = inFlight > 0 ? ` · în lucru ${inFlight}` : '';
-        progressDiv.textContent = `Progres: pagini ${pagesText}, probleme ${probsText} · timp ${formatDuration(
-            elapsedMs
-        )}${etaText}${inflightText}`;
+      const elapsedMs = Date.now() - startedAt;
+      const pagesDone = stats.pages;
+      const pagesText = Number.isFinite(totalPages) ? `${pagesDone}/${totalPages}` : `${pagesDone}`;
+      const probsText = Number.isFinite(totalProblems)
+        ? `${stats.total}/${totalProblems}`
+        : `${stats.total}`;
+      const speed = elapsedMs > 0 ? pagesDone / (elapsedMs / 1000) : 0;
+      const etaMs =
+        Number.isFinite(totalPages) && speed > 0 ? ((totalPages - pagesDone) / speed) * 1000 : null;
+      const etaText = etaMs != null ? ` · ETA ~${formatDuration(etaMs)}` : '';
+      const inflightText = inFlight > 0 ? ` · în lucru ${inFlight}` : '';
+      progressDiv.textContent = `Progres: pagini ${pagesText}, probleme ${probsText} · timp ${formatDuration(
+        elapsedMs
+      )}${etaText}${inflightText}`;
     }
 
     setupControls();
@@ -840,66 +887,66 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     updateProgress(0);
 
     function updateTable(visibleProblems) {
-        function sortSymbol(t) {
-            if (sorted[t] === 1) return '&#9660;';
-            if (sorted[t] === -1) return '&#9650;';
-            return '&#9654;';
-        }
-        function numberToDifficulty(n) {
-            return n === 0 ? 'ușoară' : n === 1 ? 'medie' : n === 2 ? 'dificilă' : 'concurs';
-        }
-        function difficultyColor(n) {
-            return n === 0 ? '5cb85c' : n === 1 ? 'f0ad4e' : n === 2 ? '5bc0de' : 'd9534f';
-        }
-        function statusLabel(s) {
-            if (s === 'solved') return 'rezolvată';
-            if (s === 'tried') return 'încercată';
-            return 'neîncercată';
-        }
-        function statusColor(s) {
-            if (s === 'solved') return '5cb85c';
-            if (s === 'tried') return 'f0ad4e';
-            return '6c757d';
-        }
+      function sortSymbol(t) {
+        if (sorted[t] === 1) return '&#9660;';
+        if (sorted[t] === -1) return '&#9650;';
+        return '&#9654;';
+      }
+      function numberToDifficulty(n) {
+        return n === 0 ? 'ușoară' : n === 1 ? 'medie' : n === 2 ? 'dificilă' : 'concurs';
+      }
+      function difficultyColor(n) {
+        return n === 0 ? '5cb85c' : n === 1 ? 'f0ad4e' : n === 2 ? '5bc0de' : 'd9534f';
+      }
+      function statusLabel(s) {
+        if (s === 'solved') return 'rezolvată';
+        if (s === 'tried') return 'încercată';
+        return 'neîncercată';
+      }
+      function statusColor(s) {
+        if (s === 'solved') return '5cb85c';
+        if (s === 'tried') return 'f0ad4e';
+        return '6c757d';
+      }
 
-        table.replaceChildren();
-        const thead = document.createElement('thead');
-        const tbody = document.createElement('tbody');
-        table.appendChild(thead);
-        table.appendChild(tbody);
+      table.replaceChildren();
+      const thead = document.createElement('thead');
+      const tbody = document.createElement('tbody');
+      table.appendChild(thead);
+      table.appendChild(tbody);
 
-        const headerDefs = [
-            { key: 'cnt', label: 'Contor', minWidth: '5em' },
-            { key: 'id', label: 'Nume', minWidth: '10em' },
-            { key: 'score', label: 'Punctaj', minWidth: '5em' },
-            { key: 'status', label: 'Stare', minWidth: '7.5em' },
-            { key: 'difficulty', label: 'Dificultate', minWidth: '6.5em' },
-            { key: 'postedBy_name', label: 'Postată de', minWidth: '13em' },
-            { key: 'author', label: 'Autor', minWidth: '10em' },
-            { key: 'source', label: 'Sursa problemei', minWidth: '10em' },
-        ];
+      const headerDefs = [
+        { key: 'cnt', label: 'Contor', minWidth: '5em' },
+        { key: 'id', label: 'Nume', minWidth: '10em' },
+        { key: 'score', label: 'Punctaj', minWidth: '5em' },
+        { key: 'status', label: 'Stare', minWidth: '7.5em' },
+        { key: 'difficulty', label: 'Dificultate', minWidth: '6.5em' },
+        { key: 'postedBy_name', label: 'Postată de', minWidth: '13em' },
+        { key: 'author', label: 'Autor', minWidth: '10em' },
+        { key: 'source', label: 'Sursa problemei', minWidth: '10em' },
+      ];
 
-        const headRow = document.createElement('tr');
-        for (const h of headerDefs) {
-            const th = document.createElement('th');
-            th.style.minWidth = h.minWidth;
-            th.style.userSelect = 'none';
-            const a = document.createElement('a');
-            a.href = '#';
-            a.innerHTML = `${h.label} ${sortSymbol(h.key)}`;
-            a.addEventListener('click', (e) => {
-                e.preventDefault();
-                sortTable(h.key);
-            });
-            th.appendChild(a);
-            headRow.appendChild(th);
-        }
-        thead.appendChild(headRow);
+      const headRow = document.createElement('tr');
+      for (const h of headerDefs) {
+        const th = document.createElement('th');
+        th.style.minWidth = h.minWidth;
+        th.style.userSelect = 'none';
+        const a = document.createElement('a');
+        a.href = '#';
+        a.innerHTML = `${h.label} ${sortSymbol(h.key)}`;
+        a.addEventListener('click', (e) => {
+          e.preventDefault();
+          sortTable(h.key);
+        });
+        th.appendChild(a);
+        headRow.appendChild(th);
+      }
+      thead.appendChild(headRow);
 
-        const list = Array.isArray(visibleProblems) ? visibleProblems : getVisibleProblems();
-        list.forEach((p, i) => {
-            const row = document.createElement('tr');
-            row.innerHTML = `<td>${i + 1}.</td>
+      const list = Array.isArray(visibleProblems) ? visibleProblems : getVisibleProblems();
+      list.forEach((p, i) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${i + 1}.</td>
                 <td><a href="${p.link}" target="_blank" rel="noopener noreferrer">#${p.id} - ${p.name}</a></td>
                 <td>${p.userScore != null && Number.isFinite(p.userScore) ? `${p.userScore}p` : '-'}</td>
                 <td><span class="pill" style="background-color:#${statusColor(p.status)};">${statusLabel(p.status)}</span></td>
@@ -907,30 +954,34 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 <td>${p.postedBy_link ? `<a target="_blank" rel="noopener noreferrer" href="${p.postedBy_link}"><img style="vertical-align:middle;width:1.1em;" src="${p.postedBy_img}"> ${p.postedBy_name}</a>` : ''}</td>
                 <td>${p.author}</td>
                 <td>${p.source}</td>`;
-            tbody.appendChild(row);
-        });
+        tbody.appendChild(row);
+      });
     }
 
     function finishScan({ complete, reason }) {
-        if (finished) return;
-        finished = true;
-        if (stopButton) stopButton.disabled = true;
+      if (finished) return;
+      finished = true;
+      if (stopButton) stopButton.disabled = true;
 
-        document.body.appendChild(table);
-        document.body.appendChild(listDiv);
-        renderResults();
+      document.body.appendChild(table);
+      document.body.appendChild(listDiv);
+      renderResults();
 
-        const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, pagini ${stats.pages}).`;
-        addLog(summary);
+      const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, pagini ${stats.pages}).`;
+      addLog(summary);
 
-        const unsolvedCount = allProblems.filter(p => p.status !== 'solved').length;
-        if (complete) {
-            addLog(`<u>Am terminat de extras problemele.</u> Sunt ${unsolvedCount} probleme nerezolvate. Tabelul și lista au fost adăugate mai jos.`);
-            return;
-        }
+      const unsolvedCount = allProblems.filter((p) => p.status !== 'solved').length;
+      if (complete) {
+        addLog(
+          `<u>Am terminat de extras problemele.</u> Sunt ${unsolvedCount} probleme nerezolvate. Tabelul și lista au fost adăugate mai jos.`
+        );
+        return;
+      }
 
-        const reasonText = reason ? ` <span style="color:#b30000;">(${reason})</span>` : '';
-        addLog(`<span style="color:#b30000;"><u>Scanarea s-a oprit înainte de final.</u></span>${reasonText}`);
+      const reasonText = reason ? ` <span style="color:#b30000;">(${reason})</span>` : '';
+      addLog(
+        `<span style="color:#b30000;"><u>Scanarea s-a oprit înainte de final.</u></span>${reasonText}`
+      );
     }
 
     // Fetch pages (optional concurrency)
@@ -940,287 +991,307 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     let inFlight = 0;
 
     function schedule(fn) {
-        if (config.delayMs > 0) setTimeout(fn, config.delayMs);
-        else fn();
+      if (config.delayMs > 0) setTimeout(fn, config.delayMs);
+      else fn();
     }
 
     function maybeFinish() {
-        if (finished) return;
-        if (queueInitialized && pageQueue.length === 0 && inFlight === 0) {
-            finishScan({ complete: true });
-        }
+      if (finished) return;
+      if (queueInitialized && pageQueue.length === 0 && inFlight === 0) {
+        finishScan({ complete: true });
+      }
     }
 
     function fetchNext() {
-        if (finished) return;
-        const next = pageQueue.shift();
-        if (next == null) {
-            maybeFinish();
-            return;
-        }
-        fetchPage(next, 0);
+      if (finished) return;
+      const next = pageQueue.shift();
+      if (next == null) {
+        maybeFinish();
+        return;
+      }
+      fetchPage(next, 0);
     }
 
     function initQueueFromTotalPages() {
-        if (queueInitialized) return;
-        if (!Number.isFinite(totalPages)) return;
-        const startAt = Math.max(1, Number.isFinite(config.startPage) ? config.startPage : 1);
-        for (let i = startAt + 1; i <= totalPages; i++) pageQueue.push(i);
-        queueInitialized = true;
-        const pagesToScan = Math.max(0, totalPages - startAt + 1);
-        const extraWorkers = Math.max(0, Math.min(config.concurrency, pagesToScan) - 1);
-        for (let i = 0; i < extraWorkers; i++) fetchNext();
+      if (queueInitialized) return;
+      if (!Number.isFinite(totalPages)) return;
+      const startAt = Math.max(1, Number.isFinite(config.startPage) ? config.startPage : 1);
+      for (let i = startAt + 1; i <= totalPages; i++) pageQueue.push(i);
+      queueInitialized = true;
+      const pagesToScan = Math.max(0, totalPages - startAt + 1);
+      const extraWorkers = Math.max(0, Math.min(config.concurrency, pagesToScan) - 1);
+      for (let i = 0; i < extraWorkers; i++) fetchNext();
     }
 
     function fetchPage(pageIndex, retryCount = 0) {
-        if (finished) return;
-        inFlight++;
+      if (finished) return;
+      inFlight++;
+      updateProgress(inFlight);
+      const xhr = new XMLHttpRequest();
+      activeRequests.add(xhr);
+      let finalized = false;
+      const finalize = () => {
+        if (finalized) return;
+        finalized = true;
+        activeRequests.delete(xhr);
+        inFlight = Math.max(0, inFlight - 1);
         updateProgress(inFlight);
-        const xhr = new XMLHttpRequest();
-        activeRequests.add(xhr);
-        let finalized = false;
-        const finalize = () => {
-            if (finalized) return;
-            finalized = true;
-            activeRequests.delete(xhr);
-            inFlight = Math.max(0, inFlight - 1);
-            updateProgress(inFlight);
-        };
-        const effectivePageSize = Number.isFinite(pageSize) ? pageSize : 10;
-        const startOffset = effectivePageSize * (pageIndex - 1);
-        const url = buildPageUrl(pageLink, {
-            pageIndex,
-            pageSize: effectivePageSize,
-            mode: config.pagination.mode,
-            param: config.pagination.param,
-            pageBase: config.pagination.pageBase,
-        });
-        xhr.open('GET', url);
-        xhr.timeout = config.timeoutMs;
-        xhr.onload = () => {
-            const responseText = xhr.responseText || xhr.response || '';
-            if (xhr.status !== 200) {
-                if (retryCount < maxRetriesPerPage) {
-                    const delay = 1000 * (retryCount + 1);
-                    addLog(`Eroare la pagina ${pageIndex} (status ${xhr.status}). Reîncerc în ${delay / 1000}s...`);
-                    finalize();
-                    setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
-                    return;
-                }
-                finalize();
-                finishScan({ complete: false, reason: `Eroare la pagina ${pageIndex} (status ${xhr.status})` });
-                return;
-            }
+      };
+      const effectivePageSize = Number.isFinite(pageSize) ? pageSize : 10;
+      const startOffset = effectivePageSize * (pageIndex - 1);
+      const url = buildPageUrl(pageLink, {
+        pageIndex,
+        pageSize: effectivePageSize,
+        mode: config.pagination.mode,
+        param: config.pagination.param,
+        pageBase: config.pagination.pageBase,
+      });
+      xhr.open('GET', url);
+      xhr.timeout = config.timeoutMs;
+      xhr.onload = () => {
+        const responseText = xhr.responseText || xhr.response || '';
+        if (xhr.status !== 200) {
+          if (retryCount < maxRetriesPerPage) {
+            const delay = 1000 * (retryCount + 1);
+            addLog(
+              `Eroare la pagina ${pageIndex} (status ${xhr.status}). Reîncerc în ${delay / 1000}s...`
+            );
+            finalize();
+            setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+            return;
+          }
+          finalize();
+          finishScan({
+            complete: false,
+            reason: `Eroare la pagina ${pageIndex} (status ${xhr.status})`,
+          });
+          return;
+        }
 
-            if (/invalid request/i.test(responseText)) {
-                if (retryCount < maxRetriesPerPage) {
-                    const delay = 1000 * (retryCount + 1);
-                    addLog(`Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
-                    finalize();
-                    setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
-                    return;
-                }
-                finalize();
-                finishScan({ complete: false, reason: `Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}` });
-                return;
-            }
+        if (/invalid request/i.test(responseText)) {
+          if (retryCount < maxRetriesPerPage) {
+            const delay = 1000 * (retryCount + 1);
+            addLog(
+              `Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`
+            );
+            finalize();
+            setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+            return;
+          }
+          finalize();
+          finishScan({
+            complete: false,
+            reason: `Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}`,
+          });
+          return;
+        }
 
-            const pageEl = document.createElement('div');
-            pageEl.innerHTML = responseText;
-            const cards = pageEl.querySelectorAll('div.card.mb-3');
+        const pageEl = document.createElement('div');
+        pageEl.innerHTML = responseText;
+        const cards = pageEl.querySelectorAll('div.card.mb-3');
 
-            if (pageIndex === firstFetchedPageIndex) {
-                if (pageSize == null && cards.length > 0) {
-                    pageSize = cards.length;
-                    addLog(`Page size detectată automat: ${pageSize}.`);
-                }
-                if (totalProblems == null) {
-                    const t = parseTotalProblems(responseText);
-                    if (Number.isFinite(t)) totalProblems = t;
-                }
-                if (Number.isFinite(totalProblems) && Number.isFinite(pageSize)) {
-                    totalPages = Math.ceil(totalProblems / pageSize);
-                }
-                updateProgress(inFlight);
-                if (!queueInitialized && Number.isFinite(totalPages)) {
-                    addLog(`Total detectat: ${totalProblems} probleme · ${totalPages} pagini · pageSize=${pageSize} · startPage=${config.startPage} · concurență=${config.concurrency}.`);
-                    initQueueFromTotalPages();
-                }
-            }
+        if (pageIndex === firstFetchedPageIndex) {
+          if (pageSize == null && cards.length > 0) {
+            pageSize = cards.length;
+            addLog(`Page size detectată automat: ${pageSize}.`);
+          }
+          if (totalProblems == null) {
+            const t = parseTotalProblems(responseText);
+            if (Number.isFinite(t)) totalProblems = t;
+          }
+          if (Number.isFinite(totalProblems) && Number.isFinite(pageSize)) {
+            totalPages = Math.ceil(totalProblems / pageSize);
+          }
+          updateProgress(inFlight);
+          if (!queueInitialized && Number.isFinite(totalPages)) {
+            addLog(
+              `Total detectat: ${totalProblems} probleme · ${totalPages} pagini · pageSize=${pageSize} · startPage=${config.startPage} · concurență=${config.concurrency}.`
+            );
+            initQueueFromTotalPages();
+          }
+        }
 
-            if (cards.length === 0) {
-                const t = totalProblems ?? parseTotalProblems(responseText);
-                if (Number.isFinite(t) && startOffset >= t) {
-                    finalize();
-                    if (queueInitialized) {
-                        pageQueue.length = 0;
-                        maybeFinish();
-                        return;
-                    }
-                    finishScan({ complete: true });
-                    return;
-                }
-                if (retryCount < maxRetriesPerPage) {
-                    const delay = 1000 * (retryCount + 1);
-                    const hint = Number.isFinite(t)
-                        ? `0 probleme, dar total=${t}`
-                        : '0 probleme';
-                    addLog(`Pagina ${pageIndex} pare goală (${hint}). Reîncerc în ${delay / 1000}s...`);
-                    finalize();
-                    setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
-                    return;
-                }
-                const hint = Number.isFinite(t)
-                    ? `Pagina ${pageIndex} goală deși totalul este ${t}`
-                    : `Pagina ${pageIndex} goală`;
-                finalize();
-                finishScan({ complete: false, reason: hint });
-                return;
-            }
-
-            stats.pages++;
-
-            let pageSolved = 0;
-            let pageTried = 0;
-            let pageUnattempted = 0;
-            let totalCount = 0;
-            let parseFailCount = 0;
-
-            for (let card of cards) {
-                const codeEl = card.querySelector('code');
-                if (!codeEl) continue;
-                const id = parseInt(codeEl.innerText.trim().slice(1));
-                if (seenProblemIds.has(id)) continue;
-                seenProblemIds.add(id);
-                totalCount++;
-                // name and link
-                let name = '';
-                let link = '';
-                const nameAnchor = card.querySelector('h5.card-title a');
-                if (nameAnchor) {
-                    name = nameAnchor.innerText.trim();
-                    link = nameAnchor.href.trim();
-                }
-                // difficulty
-                let difficulty = 3;
-                const diffEl = card.querySelector('span[title="Dificultate"]');
-                if (diffEl) {
-                    const txt = diffEl.innerText.trim().toLowerCase();
-                    if (txt.includes('ușo')) difficulty = 0;
-                    else if (txt.includes('med')) difficulty = 1;
-                    else if (txt.includes('dific')) difficulty = 2;
-                    else difficulty = 3;
-                }
-                // posted by
-                let pbLink = '', pbName = '', pbImg = '';
-                const pbAnchor = card.querySelector('span[title="Postată de"] a');
-                if (pbAnchor) {
-                    pbLink = pbAnchor.href;
-                    pbName = pbAnchor.innerText.trim();
-                    const img = pbAnchor.querySelector('img');
-                    if (img) {
-                        pbImg = img.src;
-                        try {
-                            const host = new URL(pbImg).hostname;
-                            if (host === 'www.gravatar.com') pbImg = pbImg.replace(/&s=\d+/i, '&s=128');
-                            else if (host === 'www.pbinfo.ro') pbImg = pbImg.replace(/&gsize=\d+/i, '&gsize=128');
-                        } catch {}
-                    }
-                }
-                // author
-                let author = '';
-                const authorSpan = card.querySelector('span[title="Autor"]');
-                if (authorSpan) author = authorSpan.innerText.replace(/^[\s\S]*?\s/, '').trim();
-                // source
-                let source = '';
-                const srcBlock = card.querySelector('blockquote[title="Sursa problemei"]');
-                if (srcBlock) source = srcBlock.innerText.trim();
-                const scoreInfo = extractScoreInfoFromCard(card);
-                const status = classifyProblemStatus(scoreInfo);
-
-                if (scoreInfo.candidates.length === 0) parseFailCount++;
-                if (status === 'solved') {
-                    pageSolved++;
-                    stats.solved++;
-                } else if (status === 'tried') {
-                    pageTried++;
-                    stats.tried++;
-                } else {
-                    pageUnattempted++;
-                    stats.unattempted++;
-                }
-                stats.total++;
-
-                const scoreKnown = scoreInfo.userScore != null && Number.isFinite(scoreInfo.userScore);
-                const maxScore = Number.isFinite(scoreInfo.maxScore) ? scoreInfo.maxScore : 100;
-                const score = scoreKnown ? scoreInfo.userScore : -1;
-                allProblems.push({
-                    cnt: allProblems.length + 1,
-                    id,
-                    name,
-                    link,
-                    difficulty,
-                    score,
-                    scoreKnown,
-                    userScore: scoreInfo.userScore,
-                    maxScore,
-                    status,
-                    postedBy_link: pbLink,
-                    postedBy_name: pbName,
-                    postedBy_img: pbImg,
-                    author,
-                    source,
-                });
-
-                if (shouldDebugDump(id) && (scoreInfo.candidates.length === 0 || status === 'unattempted')) {
-                    debugDumpCard(card, { id, name, link, scoreInfo });
-                }
-            }
-
-            const scoreUnavailable = pageUnattempted === totalCount;
-            const scoreWarning = scoreUnavailable ? ' (punctaj indisponibil pentru toate)' : '';
-            const parseFailSuffix = parseFailCount > 0 ? ` · parseFail=${parseFailCount}` : '';
-            addLog(`Pagina ${pageIndex}: rezolvate ${pageSolved}, încercate ${pageTried}, neîncercate ${pageUnattempted} (total ${totalCount})${scoreWarning}${parseFailSuffix}.`);
-            if (pageIndex === firstFetchedPageIndex && totalCount > 0 && scoreUnavailable) {
-                addLog(`<span style="color:#b35c00;"><b>Atenție:</b> nu pare să fie disponibil punctajul tău pe această listă. Verifică dacă ești autentificat pe pbinfo.ro.</span>`);
-            }
-
+        if (cards.length === 0) {
+          const t = totalProblems ?? parseTotalProblems(responseText);
+          if (Number.isFinite(t) && startOffset >= t) {
             finalize();
             if (queueInitialized) {
-                schedule(fetchNext);
-                return;
+              pageQueue.length = 0;
+              maybeFinish();
+              return;
             }
-            schedule(() => fetchPage(pageIndex + 1, 0));
-        };
-        xhr.onabort = () => {
+            finishScan({ complete: true });
+            return;
+          }
+          if (retryCount < maxRetriesPerPage) {
+            const delay = 1000 * (retryCount + 1);
+            const hint = Number.isFinite(t) ? `0 probleme, dar total=${t}` : '0 probleme';
+            addLog(`Pagina ${pageIndex} pare goală (${hint}). Reîncerc în ${delay / 1000}s...`);
             finalize();
-            if (stopRequested || finished) return;
-            finishScan({ complete: false, reason: `Request abort la pagina ${pageIndex}` });
-        };
-        xhr.ontimeout = () => {
-            finalize();
-            if (retryCount < maxRetriesPerPage) {
-                const delay = 1000 * (retryCount + 1);
-                addLog(`Timeout la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
-                setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
-                return;
+            setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+            return;
+          }
+          const hint = Number.isFinite(t)
+            ? `Pagina ${pageIndex} goală deși totalul este ${t}`
+            : `Pagina ${pageIndex} goală`;
+          finalize();
+          finishScan({ complete: false, reason: hint });
+          return;
+        }
+
+        stats.pages++;
+
+        let pageSolved = 0;
+        let pageTried = 0;
+        let pageUnattempted = 0;
+        let totalCount = 0;
+        let parseFailCount = 0;
+
+        for (let card of cards) {
+          const codeEl = card.querySelector('code');
+          if (!codeEl) continue;
+          const id = parseInt(codeEl.innerText.trim().slice(1));
+          if (seenProblemIds.has(id)) continue;
+          seenProblemIds.add(id);
+          totalCount++;
+          // name and link
+          let name = '';
+          let link = '';
+          const nameAnchor = card.querySelector('h5.card-title a');
+          if (nameAnchor) {
+            name = nameAnchor.innerText.trim();
+            link = nameAnchor.href.trim();
+          }
+          // difficulty
+          let difficulty = 3;
+          const diffEl = card.querySelector('span[title="Dificultate"]');
+          if (diffEl) {
+            const txt = diffEl.innerText.trim().toLowerCase();
+            if (txt.includes('ușo')) difficulty = 0;
+            else if (txt.includes('med')) difficulty = 1;
+            else if (txt.includes('dific')) difficulty = 2;
+            else difficulty = 3;
+          }
+          // posted by
+          let pbLink = '',
+            pbName = '',
+            pbImg = '';
+          const pbAnchor = card.querySelector('span[title="Postată de"] a');
+          if (pbAnchor) {
+            pbLink = pbAnchor.href;
+            pbName = pbAnchor.innerText.trim();
+            const img = pbAnchor.querySelector('img');
+            if (img) {
+              pbImg = img.src;
+              try {
+                const host = new URL(pbImg).hostname;
+                if (host === 'www.gravatar.com') pbImg = pbImg.replace(/&s=\d+/i, '&s=128');
+                else if (host === 'www.pbinfo.ro')
+                  pbImg = pbImg.replace(/&gsize=\d+/i, '&gsize=128');
+              } catch {}
             }
-            finishScan({ complete: false, reason: `Timeout la pagina ${pageIndex}` });
-        };
-        xhr.onerror = () => {
-            finalize();
-            if (stopRequested || finished) return;
-            if (retryCount < maxRetriesPerPage) {
-                const delay = 1000 * (retryCount + 1);
-                addLog(`Eroare de rețea la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
-                setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
-                return;
-            }
-            finishScan({ complete: false, reason: `Eroare de rețea la pagina ${pageIndex}` });
-        };
-        xhr.send();
+          }
+          // author
+          let author = '';
+          const authorSpan = card.querySelector('span[title="Autor"]');
+          if (authorSpan) author = authorSpan.innerText.replace(/^[\s\S]*?\s/, '').trim();
+          // source
+          let source = '';
+          const srcBlock = card.querySelector('blockquote[title="Sursa problemei"]');
+          if (srcBlock) source = srcBlock.innerText.trim();
+          const scoreInfo = extractScoreInfoFromCard(card);
+          const status = classifyProblemStatus(scoreInfo);
+
+          if (scoreInfo.candidates.length === 0) parseFailCount++;
+          if (status === 'solved') {
+            pageSolved++;
+            stats.solved++;
+          } else if (status === 'tried') {
+            pageTried++;
+            stats.tried++;
+          } else {
+            pageUnattempted++;
+            stats.unattempted++;
+          }
+          stats.total++;
+
+          const scoreKnown = scoreInfo.userScore != null && Number.isFinite(scoreInfo.userScore);
+          const maxScore = Number.isFinite(scoreInfo.maxScore) ? scoreInfo.maxScore : 100;
+          const score = scoreKnown ? scoreInfo.userScore : -1;
+          allProblems.push({
+            cnt: allProblems.length + 1,
+            id,
+            name,
+            link,
+            difficulty,
+            score,
+            scoreKnown,
+            userScore: scoreInfo.userScore,
+            maxScore,
+            status,
+            postedBy_link: pbLink,
+            postedBy_name: pbName,
+            postedBy_img: pbImg,
+            author,
+            source,
+          });
+
+          if (
+            shouldDebugDump(id) &&
+            (scoreInfo.candidates.length === 0 || status === 'unattempted')
+          ) {
+            debugDumpCard(card, { id, name, link, scoreInfo });
+          }
+        }
+
+        const scoreUnavailable = pageUnattempted === totalCount;
+        const scoreWarning = scoreUnavailable ? ' (punctaj indisponibil pentru toate)' : '';
+        const parseFailSuffix = parseFailCount > 0 ? ` · parseFail=${parseFailCount}` : '';
+        addLog(
+          `Pagina ${pageIndex}: rezolvate ${pageSolved}, încercate ${pageTried}, neîncercate ${pageUnattempted} (total ${totalCount})${scoreWarning}${parseFailSuffix}.`
+        );
+        if (pageIndex === firstFetchedPageIndex && totalCount > 0 && scoreUnavailable) {
+          addLog(
+            `<span style="color:#b35c00;"><b>Atenție:</b> nu pare să fie disponibil punctajul tău pe această listă. Verifică dacă ești autentificat pe pbinfo.ro.</span>`
+          );
+        }
+
+        finalize();
+        if (queueInitialized) {
+          schedule(fetchNext);
+          return;
+        }
+        schedule(() => fetchPage(pageIndex + 1, 0));
+      };
+      xhr.onabort = () => {
+        finalize();
+        if (stopRequested || finished) return;
+        finishScan({ complete: false, reason: `Request abort la pagina ${pageIndex}` });
+      };
+      xhr.ontimeout = () => {
+        finalize();
+        if (retryCount < maxRetriesPerPage) {
+          const delay = 1000 * (retryCount + 1);
+          addLog(`Timeout la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
+          setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+          return;
+        }
+        finishScan({ complete: false, reason: `Timeout la pagina ${pageIndex}` });
+      };
+      xhr.onerror = () => {
+        finalize();
+        if (stopRequested || finished) return;
+        if (retryCount < maxRetriesPerPage) {
+          const delay = 1000 * (retryCount + 1);
+          addLog(`Eroare de rețea la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
+          setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+          return;
+        }
+        finishScan({ complete: false, reason: `Eroare de rețea la pagina ${pageIndex}` });
+      };
+      xhr.send();
     }
 
     fetchPage(config.startPage, 0);
-})();
+  })();
 }

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -677,7 +677,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       const shown = visible.length;
       const total = allProblems.length;
       const unsolved = allProblems.filter((p) => p.status !== 'solved').length;
-      summaryDiv.innerHTML = `<b>Statistici:</b> scanate=${total} · nerezolvate=${unsolved} · afișate=${shown} · pagini=${stats.pages}`;
+      summaryDiv.replaceChildren();
+      const b = document.createElement('b');
+      b.textContent = 'Statistici:';
+      summaryDiv.appendChild(b);
+      summaryDiv.appendChild(
+        document.createTextNode(
+          ` scanate=${total} · nerezolvate=${unsolved} · afișate=${shown} · pagini=${stats.pages}`
+        )
+      );
     }
 
     function updateList(visible) {
@@ -686,25 +694,65 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       const solved = visible.filter((p) => p.status === 'solved');
 
       function mkList(items) {
-        if (items.length === 0) return '<span class="muted">-</span>';
-        return `<ul style="list-style:none;padding-left:0;margin:0;">${items
-          .map(
-            (p) =>
-              `<li style="margin:0.15em 0;"><a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a></li>`
-          )
-          .join('')}</ul>`;
+        if (items.length === 0) {
+          const muted = document.createElement('span');
+          muted.className = 'muted';
+          muted.textContent = '-';
+          return muted;
+        }
+
+        const ul = document.createElement('ul');
+        ul.style.listStyle = 'none';
+        ul.style.paddingLeft = '0';
+        ul.style.margin = '0';
+        for (const p of items) {
+          const li = document.createElement('li');
+          li.style.margin = '0.15em 0';
+          const a = document.createElement('a');
+          a.href = p.link;
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          a.textContent = `#${p.id} - ${p.name}`;
+          li.appendChild(a);
+          ul.appendChild(li);
+        }
+        return ul;
       }
 
-      listDiv.innerHTML = `<h3>Lista (filtrată):</h3>
-            <div style="margin-bottom:0.5em;">
-                Încercate: <b>${tried.length}</b> · Neîncercate: <b>${unattempted.length}</b> · Rezolvate: <b>${solved.length}</b>
-            </div>
-            <h4 style="margin:0.75em 0 0.25em;">Încercate</h4>
-            ${mkList(tried)}
-            <h4 style="margin:0.75em 0 0.25em;">Neîncercate</h4>
-            ${mkList(unattempted)}
-            <h4 style="margin:0.75em 0 0.25em;">Rezolvate</h4>
-            ${mkList(solved)}`;
+      listDiv.replaceChildren();
+
+      const h3 = document.createElement('h3');
+      h3.textContent = 'Lista (filtrată):';
+      listDiv.appendChild(h3);
+
+      const counts = document.createElement('div');
+      counts.style.marginBottom = '0.5em';
+      counts.appendChild(document.createTextNode('Încercate: '));
+      const triedB = document.createElement('b');
+      triedB.textContent = String(tried.length);
+      counts.appendChild(triedB);
+      counts.appendChild(document.createTextNode(' · Neîncercate: '));
+      const unattemptedB = document.createElement('b');
+      unattemptedB.textContent = String(unattempted.length);
+      counts.appendChild(unattemptedB);
+      counts.appendChild(document.createTextNode(' · Rezolvate: '));
+      const solvedB = document.createElement('b');
+      solvedB.textContent = String(solved.length);
+      counts.appendChild(solvedB);
+      listDiv.appendChild(counts);
+
+      const sections = [
+        { label: 'Încercate', items: tried },
+        { label: 'Neîncercate', items: unattempted },
+        { label: 'Rezolvate', items: solved },
+      ];
+      for (const s of sections) {
+        const h4 = document.createElement('h4');
+        h4.style.margin = '0.75em 0 0.25em';
+        h4.textContent = s.label;
+        listDiv.appendChild(h4);
+        listDiv.appendChild(mkList(s.items));
+      }
     }
 
     function renderResults() {
@@ -957,19 +1005,36 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     function updateProgress(inFlight) {
       const elapsedMs = Date.now() - startedAt;
       const pagesDone = stats.pages;
-      const pagesText = Number.isFinite(totalPages) ? `${pagesDone}/${totalPages}` : `${pagesDone}`;
-      const probsText = Number.isFinite(totalProblems)
-        ? `${stats.total}/${totalProblems}`
-        : `${stats.total}`;
+      const scanStart = Math.max(1, Number.isFinite(config.startPage) ? config.startPage : 1);
+      const scanPagesTotal = Number.isFinite(totalPages)
+        ? Math.max(0, totalPages - scanStart + 1)
+        : null;
+      const pagesText =
+        scanPagesTotal != null && scanPagesTotal > 0
+          ? `${pagesDone}/${scanPagesTotal}`
+          : `${pagesDone}`;
+      const scanProblemsTotal =
+        Number.isFinite(totalProblems) && Number.isFinite(pageSize)
+          ? Math.max(0, totalProblems - pageSize * (scanStart - 1))
+          : null;
+      const probsText =
+        scanProblemsTotal != null && scanProblemsTotal > 0
+          ? `${stats.total}/${scanProblemsTotal}`
+          : Number.isFinite(totalProblems)
+            ? `${stats.total}/${totalProblems}`
+            : `${stats.total}`;
       const speed = elapsedMs > 0 ? pagesDone / (elapsedMs / 1000) : 0;
       const etaMs =
-        Number.isFinite(totalPages) && speed > 0 ? ((totalPages - pagesDone) / speed) * 1000 : null;
+        scanPagesTotal != null && scanPagesTotal > 0 && speed > 0
+          ? ((scanPagesTotal - pagesDone) / speed) * 1000
+          : null;
       const etaText = etaMs != null ? ` · ETA ~${formatDuration(etaMs)}` : '';
       const pauseText = paused ? ' · pauză' : '';
       const inflightText = inFlight > 0 ? ` · în lucru ${inFlight}` : '';
+      const startText = scanStart > 1 ? ` (de la ${scanStart})` : '';
       progressDiv.textContent = `Progres: pagini ${pagesText}, probleme ${probsText} · timp ${formatDuration(
         elapsedMs
-      )}${etaText}${pauseText}${inflightText}`;
+      )}${etaText}${pauseText}${inflightText}${startText}`;
     }
 
     setupControls();
@@ -1036,14 +1101,69 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       const list = Array.isArray(visibleProblems) ? visibleProblems : getVisibleProblems();
       list.forEach((p, i) => {
         const row = document.createElement('tr');
-        row.innerHTML = `<td>${i + 1}.</td>
-                <td><a href="${p.link}" target="_blank" rel="noopener noreferrer">#${p.id} - ${p.name}</a></td>
-                <td>${p.userScore != null && Number.isFinite(p.userScore) ? `${p.userScore}p` : '-'}</td>
-                <td><span class="pill" style="background-color:#${statusColor(p.status)};">${statusLabel(p.status)}</span></td>
-                <td><span class="pill" style="background-color:#${difficultyColor(p.difficulty)};">${numberToDifficulty(p.difficulty)}</span></td>
-                <td>${p.postedBy_link ? `<a target="_blank" rel="noopener noreferrer" href="${p.postedBy_link}"><img style="vertical-align:middle;width:1.1em;" src="${p.postedBy_img}"> ${p.postedBy_name}</a>` : ''}</td>
-                <td>${p.author}</td>
-                <td>${p.source}</td>`;
+
+        const tdCnt = document.createElement('td');
+        tdCnt.textContent = `${i + 1}.`;
+        row.appendChild(tdCnt);
+
+        const tdName = document.createElement('td');
+        const nameA = document.createElement('a');
+        nameA.href = p.link;
+        nameA.target = '_blank';
+        nameA.rel = 'noopener noreferrer';
+        nameA.textContent = `#${p.id} - ${p.name}`;
+        tdName.appendChild(nameA);
+        row.appendChild(tdName);
+
+        const tdScore = document.createElement('td');
+        tdScore.textContent =
+          p.userScore != null && Number.isFinite(p.userScore) ? `${p.userScore}p` : '-';
+        row.appendChild(tdScore);
+
+        const tdStatus = document.createElement('td');
+        const statusSpan = document.createElement('span');
+        statusSpan.className = 'pill';
+        statusSpan.style.backgroundColor = `#${statusColor(p.status)}`;
+        statusSpan.textContent = statusLabel(p.status);
+        tdStatus.appendChild(statusSpan);
+        row.appendChild(tdStatus);
+
+        const tdDifficulty = document.createElement('td');
+        const diffSpan = document.createElement('span');
+        diffSpan.className = 'pill';
+        diffSpan.style.backgroundColor = `#${difficultyColor(p.difficulty)}`;
+        diffSpan.textContent = numberToDifficulty(p.difficulty);
+        tdDifficulty.appendChild(diffSpan);
+        row.appendChild(tdDifficulty);
+
+        const tdPostedBy = document.createElement('td');
+        if (p.postedBy_link) {
+          const pbA = document.createElement('a');
+          pbA.href = p.postedBy_link;
+          pbA.target = '_blank';
+          pbA.rel = 'noopener noreferrer';
+          if (p.postedBy_img) {
+            const img = document.createElement('img');
+            img.style.verticalAlign = 'middle';
+            img.style.width = '1.1em';
+            img.src = p.postedBy_img;
+            img.alt = '';
+            pbA.appendChild(img);
+            pbA.appendChild(document.createTextNode(' '));
+          }
+          pbA.appendChild(document.createTextNode(p.postedBy_name || ''));
+          tdPostedBy.appendChild(pbA);
+        }
+        row.appendChild(tdPostedBy);
+
+        const tdAuthor = document.createElement('td');
+        tdAuthor.textContent = p.author || '';
+        row.appendChild(tdAuthor);
+
+        const tdSource = document.createElement('td');
+        tdSource.textContent = p.source || '';
+        row.appendChild(tdSource);
+
         tbody.appendChild(row);
       });
     }
@@ -1256,9 +1376,16 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         const cards = pageEl.querySelectorAll('div.card.mb-3');
 
         if (pageIndex === firstFetchedPageIndex) {
-          if (pageSize == null && cards.length > 0) {
-            pageSize = cards.length;
-            addLog(`Page size detectată automat: ${pageSize}.`);
+          if (pageSize == null) {
+            if (pageIndex === 1 && cards.length > 0) {
+              pageSize = cards.length;
+              addLog(`Page size detectată automat: ${pageSize}.`);
+            } else {
+              pageSize = effectivePageSize;
+              addLog(
+                `Page size implicită: ${pageSize} (pentru resume; setează PBINFO_GET_UNSOLVED_PAGE_SIZE dacă e diferit).`
+              );
+            }
           }
           if (totalProblems == null) {
             const t = parseTotalProblems(responseText);

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -1375,6 +1375,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       finishScan({ complete: false, reason: reason || 'Oprit de utilizator' });
     }
 
+    function closeOverlay() {
+      if (!overlayEnabled) return;
+      if (!finished && !stopRequested) {
+        const ok = confirm('Închizi overlay-ul? Scanarea va fi oprită.');
+        if (!ok) return;
+        stopScan('Oprit de utilizator');
+      }
+      try {
+        document.getElementById(UI_ROOT_ID)?.remove();
+      } catch {}
+      try {
+        document.getElementById(UI_STYLE_ID)?.remove();
+      } catch {}
+    }
+
     function togglePause() {
       if (finished || stopRequested) return;
       paused = !paused;
@@ -1770,6 +1785,13 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       stopButton.addEventListener('click', () => stopScan('Oprit de utilizator'));
       groupScan.appendChild(stopButton);
 
+      if (overlayEnabled) {
+        const closeOverlayBtn = document.createElement('button');
+        closeOverlayBtn.textContent = 'Închide overlay';
+        closeOverlayBtn.addEventListener('click', closeOverlay);
+        groupScan.appendChild(closeOverlayBtn);
+      }
+
       const scanNote = document.createElement('div');
       scanNote.className = 'muted';
       scanNote.textContent =
@@ -2037,6 +2059,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     let inFlight = 0;
     let idRangeConsecutiveMissing = 0;
     let idRangeWarnedAboutScore = false;
+    let idRangeWarnedAboutForbidden = false;
     const idRangeLogEvery = Math.max(
       50,
       Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_ID_LOG_EVERY))
@@ -2799,6 +2822,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         return;
       }
 
+      let knownIdRangeScore = null;
       if (scanMode === 'id-range') {
         const prefetch = getIdRangeScorePrefetchState(pageIndex);
         if (prefetch.pending) {
@@ -2806,9 +2830,14 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           return;
         }
         if (prefetch.cached && Number.isFinite(prefetch.cached.value)) {
-          if (processIdRangeFromScoreBatch(pageIndex, prefetch.cached)) {
-            schedule(kick);
-            return;
+          const scoreValue = prefetch.cached.value;
+          if (scoreValue >= 100) {
+            if (processIdRangeFromScoreBatch(pageIndex, prefetch.cached)) {
+              schedule(kick);
+              return;
+            }
+          } else {
+            knownIdRangeScore = scoreValue;
           }
         }
       }
@@ -2911,9 +2940,45 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           stats.forbidden++;
           idRangeConsecutiveMissing = 0;
           maybeAutoSave('id');
-          addLog(
-            `<span style="color:#b35c00;"><b>Atenție:</b> ${unitLabel} a răspuns cu status ${xhr.status} (Acces interzis). Sar peste și continui scanarea.</span>`
-          );
+
+          if (!idRangeWarnedAboutForbidden) {
+            idRangeWarnedAboutForbidden = true;
+            addLog(
+              `<span style="color:#b35c00;"><b>Notă:</b> unele ID-uri răspund cu 401/403 (Acces interzis). Le sar și continui scanarea.</span>`
+            );
+          }
+
+          const scoreValue =
+            knownIdRangeScore != null && Number.isFinite(knownIdRangeScore)
+              ? knownIdRangeScore
+              : null;
+          if (scoreValue != null && !seenProblemIds.has(pageIndex)) {
+            seenProblemIds.add(pageIndex);
+            allProblems.push({
+              cnt: allProblems.length + 1,
+              id: pageIndex,
+              name: '',
+              link: new URL(
+                `/probleme/${pageIndex}`,
+                location?.origin || 'https://www.pbinfo.ro'
+              ).toString(),
+              difficulty: 3,
+              score: scoreValue,
+              scoreKnown: true,
+              userScore: scoreValue,
+              maxScore: 100,
+              status: scoreValue >= 100 ? 'solved' : 'tried',
+              postedBy_link: '',
+              postedBy_name: '',
+              postedBy_img: '',
+              author: '',
+              source: '',
+            });
+            if (scoreValue >= 100) stats.solved++;
+            else stats.tried++;
+            stats.total++;
+          }
+
           finalize();
           schedule(kick);
           return;
@@ -2974,7 +3039,13 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 ).toString();
 
           const meta = extractProblemMetaFromProblemPage(pageEl, pageIndex);
-          const scoreInfo = extractScoreInfoFromProblemPage(pageEl);
+          const rawScoreInfo = extractScoreInfoFromProblemPage(pageEl);
+          const scoreInfo =
+            knownIdRangeScore != null &&
+            Number.isFinite(knownIdRangeScore) &&
+            (rawScoreInfo.userScore == null || !Number.isFinite(rawScoreInfo.userScore))
+              ? { ...rawScoreInfo, userScore: knownIdRangeScore, maxScore: 100 }
+              : rawScoreInfo;
           const status = classifyProblemStatus(scoreInfo);
 
           if (!pageEl.querySelector('#scor_utilizator_problema') && !idRangeWarnedAboutScore) {

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -79,9 +79,95 @@ function selectScoreFromCandidates(candidates) {
     return { userScore: best.value, maxScore };
 }
 
+const tooltipAttrs = ['title', 'data-bs-title', 'data-bs-original-title', 'data-original-title'];
+function getTooltipText(el) {
+    for (const attr of tooltipAttrs) {
+        const v = el.getAttribute?.(attr);
+        if (v) return v;
+    }
+    return '';
+}
+
+function buildScoreCandidatesFromCard(card) {
+    const candidates = [];
+
+    const tooltipEls = Array.from(card.querySelectorAll('[title],[data-bs-title],[data-bs-original-title],[data-original-title]'));
+    for (const el of tooltipEls) {
+        const tooltip = normalizeForMatch(getTooltipText(el));
+        if (!tooltip) continue;
+        if (!tooltip.includes('punctaj') && !tooltip.includes('scor') && !tooltip.includes('score')) continue;
+
+        const text = normalizeSpace(el.textContent);
+        const parsed = parseScoreText(text);
+        if (!parsed) continue;
+
+        candidates.push({
+            el,
+            tooltip: getTooltipText(el),
+            text,
+            value: parsed.value,
+            max: parsed.max,
+            hasRatio: parsed.hasRatio,
+            isLink: el.tagName === 'A',
+        });
+    }
+
+    if (candidates.length === 0) {
+        const badgeEls = Array.from(card.querySelectorAll('span.badge, a.badge, div.badge'))
+            .filter(el => !normalizeSpace(el.textContent).startsWith('#'));
+        for (const el of badgeEls) {
+            const text = normalizeSpace(el.textContent);
+            const parsed = parseScoreText(text);
+            if (!parsed) continue;
+            if (!/\bp\b/i.test(text) && !parsed.hasRatio) continue;
+            candidates.push({
+                el,
+                tooltip: getTooltipText(el),
+                text,
+                value: parsed.value,
+                max: parsed.max,
+                hasRatio: parsed.hasRatio,
+                isLink: el.tagName === 'A',
+            });
+        }
+    }
+
+    return candidates;
+}
+
+function extractScoreInfoFromCard(card) {
+    const candidates = buildScoreCandidatesFromCard(card);
+    const { userScore, maxScore } = selectScoreFromCandidates(candidates);
+    return { userScore, maxScore, candidates };
+}
+
+function classifyProblemStatus(scoreInfo) {
+    const maxPoints = Number.isFinite(scoreInfo?.maxScore) ? scoreInfo.maxScore : 100;
+    if (scoreInfo?.userScore == null) return 'unattempted';
+    if (scoreInfo.userScore >= maxPoints) return 'solved';
+    return 'tried';
+}
+
+function parseTotalProblems(html) {
+    const m = /class="[^"]*\bnumar_probleme\b[^"]*"[^>]*>\s*([0-9]+)\s*</i.exec(html || '');
+    if (!m) return null;
+    const n = parseInt(m[1], 10);
+    return Number.isFinite(n) ? n : null;
+}
+
 if (typeof window === 'undefined' || typeof document === 'undefined') {
     if (typeof module !== 'undefined') {
-        module.exports = { normalizeSpace, normalizeForMatch, parseScoreText, selectScoreFromCandidates };
+        module.exports = {
+            normalizeSpace,
+            normalizeForMatch,
+            parseScoreText,
+            selectScoreFromCandidates,
+            getTooltipText,
+            buildScoreCandidatesFromCard,
+            extractScoreInfoFromCard,
+            classifyProblemStatus,
+            parseTotalProblems,
+        };
     }
 } else {
 (function () {
@@ -131,13 +217,78 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     addLog('Link către lista de probleme: <a href="' + pageLink + '"><i>' + pageLink + '</i></a>');
 
+    const pageSize = 10;
+    const stats = { solved: 0, tried: 0, unattempted: 0, total: 0, pages: 0 };
+    let finished = false;
+
+    const debugEnabled = Boolean(window.PBINFO_GET_UNSOLVED_DEBUG);
+    const debugDumpLimit = Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_DEBUG_LIMIT))
+        ? Number(window.PBINFO_GET_UNSOLVED_DEBUG_LIMIT)
+        : 20;
+    const debugIncludeHtml = Boolean(window.PBINFO_GET_UNSOLVED_DEBUG_HTML);
+    const debugIds = Array.isArray(window.PBINFO_GET_UNSOLVED_DEBUG_IDS)
+        ? new Set(window.PBINFO_GET_UNSOLVED_DEBUG_IDS.map(n => parseInt(n, 10)).filter(Number.isFinite))
+        : null;
+    let debugDumped = 0;
+
+    if (debugEnabled) {
+        addLog(`<span style="color:#b35c00;"><b>Debug:</b> activ (limită dump=${debugDumpLimit}${debugIds ? `, ids=${Array.from(debugIds).join(',')}` : ''}).</span>`);
+    }
+
+    function shouldDebugDump(id) {
+        if (!debugEnabled) return false;
+        if (debugDumped >= debugDumpLimit) return false;
+        if (debugIds && !debugIds.has(id)) return false;
+        return true;
+    }
+
+    function debugDumpCard(card, meta) {
+        debugDumped++;
+
+        const tooltipEls = Array.from(card.querySelectorAll('[title],[data-bs-title],[data-bs-original-title],[data-original-title]'));
+        const tooltips = tooltipEls
+            .map(el => ({
+                tag: el.tagName,
+                tooltip: getTooltipText(el),
+                text: normalizeSpace(el.textContent),
+            }))
+            .filter(x => x.tooltip || x.text);
+
+        const badges = Array.from(card.querySelectorAll('.badge'))
+            .map(el => normalizeSpace(el.textContent))
+            .filter(Boolean);
+
+        const candidates = (meta.scoreInfo?.candidates || []).map(c => ({
+            tag: c.el?.tagName,
+            tooltip: c.tooltip,
+            text: c.text,
+            value: c.value,
+            max: c.max,
+            hasRatio: c.hasRatio,
+        }));
+
+        console.log('pbinfo-get-unsolved debug:', {
+            id: meta.id,
+            name: meta.name,
+            link: meta.link,
+            scoreInfo: { userScore: meta.scoreInfo?.userScore, maxScore: meta.scoreInfo?.maxScore },
+            candidates,
+            tooltips,
+            badges,
+        });
+
+        if (debugIncludeHtml) {
+            console.log('pbinfo-get-unsolved debug card html:', (card.outerHTML || '').slice(0, 5000));
+        }
+    }
+
     const reqPageEl = document.createElement('div');
     reqPageEl.style.display = 'none';
     document.body.appendChild(reqPageEl);
 
     const problems = [];
     const seenProblemIds = new Set();
-    const sorted = { cnt: 1, id: 0, score: 0, difficulty: 0, postedBy_name: 0, author: 0, source: 0 };
+    const sorted = { cnt: 1, id: 0, score: 0, status: 0, difficulty: 0, postedBy_name: 0, author: 0, source: 0 };
     const table = document.createElement('table');
     table.style.width = '75%';
     table.style.minWidth = '450px';
@@ -192,10 +343,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         function difficultyColor(n) {
             return n === 0 ? '5cb85c' : n === 1 ? 'f0ad4e' : n === 2 ? '5bc0de' : 'd9534f';
         }
+        function statusLabel(s) {
+            if (s === 'solved') return 'rezolvată';
+            if (s === 'tried') return 'încercată';
+            return 'neîncercată';
+        }
+        function statusColor(s) {
+            if (s === 'solved') return '5cb85c';
+            if (s === 'tried') return 'f0ad4e';
+            return '6c757d';
+        }
         table.innerHTML = `<tr style="font-weight:bold;">
             <td style="min-width:5em;user-select:none;"><a onclick="sortTable('cnt')">Contor ${sortSymbol('cnt')}</a></td>
             <td style="min-width:10em;user-select:none;"><a onclick="sortTable('id')">Nume ${sortSymbol('id')}</a></td>
             <td style="min-width:5em;user-select:none;"><a onclick="sortTable('score')">Punctaj ${sortSymbol('score')}</a></td>
+            <td style="min-width:7.5em;user-select:none;"><a onclick="sortTable('status')">Stare ${sortSymbol('status')}</a></td>
             <td style="min-width:6.5em;user-select:none;"><a onclick="sortTable('difficulty')">Dificultate ${sortSymbol('difficulty')}</a></td>
             <td style="min-width:13em;user-select:none;"><a onclick="sortTable('postedBy_name')">Postată de ${sortSymbol('postedBy_name')}</a></td>
             <td style="min-width:10em;user-select:none;"><a onclick="sortTable('author')">Autor ${sortSymbol('author')}</a></td>
@@ -205,7 +367,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             const row = document.createElement('tr');
             row.innerHTML = `<td>${p.cnt}.</td>
                 <td><a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a></td>
-                <td>${p.score}p</td>
+                <td>${p.scoreKnown ? `${p.score}p` : '-'}</td>
+                <td><span style="color:white;background-color:#${statusColor(p.status)};">${statusLabel(p.status)}</span></td>
                 <td><span style="color:white;background-color:#${difficultyColor(p.difficulty)};">${numberToDifficulty(p.difficulty)}</span></td>
                 <td><a target="_blank" href="${p.postedBy_link}"><img style="vertical-align:middle;width:1.1em;" src="${p.postedBy_img}"> ${p.postedBy_name}</a></td>
                 <td>${p.author}</td>
@@ -214,67 +377,67 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         });
     }
 
-    const tooltipAttrs = ['title', 'data-bs-title', 'data-bs-original-title', 'data-original-title'];
-    function getTooltipText(el) {
-        for (const attr of tooltipAttrs) {
-            const v = el.getAttribute(attr);
-            if (v) return v;
-        }
-        return '';
-    }
+    function finishScan({ complete, reason }) {
+        if (finished) return;
+        finished = true;
 
-    function extractScoreInfo(card) {
-        const candidates = [];
+        updateTable();
+        document.body.appendChild(table);
 
-        const tooltipEls = Array.from(card.querySelectorAll('[title],[data-bs-title],[data-bs-original-title],[data-original-title]'));
-        for (const el of tooltipEls) {
-            const tooltip = normalizeForMatch(getTooltipText(el));
-            if (!tooltip) continue;
-            if (!tooltip.includes('punctaj') && !tooltip.includes('scor') && !tooltip.includes('score')) continue;
+        const tried = problems.filter(p => p.status === 'tried');
+        const unattempted = problems.filter(p => p.status === 'unattempted');
 
-            const text = normalizeSpace(el.textContent);
-            const parsed = parseScoreText(text);
-            if (!parsed) continue;
+        const listDiv = document.createElement('div');
+        listDiv.style.marginTop = '1em';
+        listDiv.innerHTML = `<h3>Lista problemelor nerezolvate:</h3>
+            <div style="margin-bottom:0.5em;">
+                Încercate: <b>${tried.length}</b> · Neîncercate: <b>${unattempted.length}</b>
+            </div>`;
 
-            candidates.push({
-                el,
-                tooltip: getTooltipText(el),
-                text,
-                value: parsed.value,
-                max: parsed.max,
-                hasRatio: parsed.hasRatio,
-                isLink: el.tagName === 'A',
+        function appendList(titleText, items) {
+            if (items.length === 0) return;
+            const h = document.createElement('h4');
+            h.textContent = titleText;
+            h.style.margin = '0.75em 0 0.25em';
+            const ul = document.createElement('ul');
+            ul.style.listStyle = 'none';
+            ul.style.paddingLeft = '0';
+            items.forEach(p => {
+                const li = document.createElement('li');
+                li.style.marginBottom = '0.25em';
+                li.innerHTML = `<a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a>`;
+                ul.appendChild(li);
             });
+            listDiv.appendChild(h);
+            listDiv.appendChild(ul);
         }
 
-        if (candidates.length === 0) {
-            const badgeEls = Array.from(card.querySelectorAll('span.badge, a.badge, div.badge'))
-                .filter(el => !normalizeSpace(el.textContent).startsWith('#'));
-            for (const el of badgeEls) {
-                const text = normalizeSpace(el.textContent);
-                const parsed = parseScoreText(text);
-                if (!parsed) continue;
-                if (!/\bp\b/i.test(text) && !parsed.hasRatio) continue;
-                candidates.push({
-                    el,
-                    tooltip: getTooltipText(el),
-                    text,
-                    value: parsed.value,
-                    max: parsed.max,
-                    hasRatio: parsed.hasRatio,
-                    isLink: el.tagName === 'A',
-                });
-            }
+        appendList('Încercate (punctaj < maxim)', tried);
+        appendList('Neîncercate (punctaj indisponibil)', unattempted);
+
+        if (tried.length + unattempted.length > 0) {
+            document.body.appendChild(listDiv);
         }
 
-        return selectScoreFromCandidates(candidates);
+        const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, pagini ${stats.pages}).`;
+        addLog(summary);
+
+        if (complete) {
+            addLog(`<u>Am terminat de extras problemele.</u> Sunt ${problems.length} probleme nerezolvate. Tabelul și lista au fost adăugate mai jos.`);
+            return;
+        }
+
+        const reasonText = reason ? ` <span style="color:#b30000;">(${reason})</span>` : '';
+        addLog(`<span style="color:#b30000;"><u>Scanarea s-a oprit înainte de final.</u></span>${reasonText}`);
     }
 
     // Fetch pages recursively
     const maxRetriesPerPage = 3;
     (function fetchPage(pageIndex, retryCount = 0) {
+        if (finished) return;
         const xhr = new XMLHttpRequest();
-        const url = pageLink + (pageLink.includes('?') ? '&' : '?') + 'start=' + 10 * (pageIndex - 1);
+        const startOffset = pageSize * (pageIndex - 1);
+        const url = pageLink + (pageLink.includes('?') ? '&' : '?') + 'start=' + startOffset;
         xhr.open('GET', url);
         xhr.timeout = 30000;
         xhr.onload = () => {
@@ -286,7 +449,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                     setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
                     return;
                 }
-                addLog(`Eroare la pagina ${pageIndex} (status ${xhr.status}). Oprire.`);
+                finishScan({ complete: false, reason: `Eroare la pagina ${pageIndex} (status ${xhr.status})` });
                 return;
             }
 
@@ -297,15 +460,43 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                     setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
                     return;
                 }
-                addLog(`Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}. Oprire.`);
+                finishScan({ complete: false, reason: `Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}` });
                 return;
             }
 
             reqPageEl.innerHTML = responseText;
             const cards = reqPageEl.querySelectorAll('div.card.mb-3');
-            let solvedCount = 0;
+
+            if (cards.length === 0) {
+                const totalProblems = parseTotalProblems(responseText);
+                if (Number.isFinite(totalProblems) && startOffset >= totalProblems) {
+                    finishScan({ complete: true });
+                    return;
+                }
+                if (retryCount < maxRetriesPerPage) {
+                    const delay = 1000 * (retryCount + 1);
+                    const hint = Number.isFinite(totalProblems)
+                        ? `0 probleme, dar total=${totalProblems}`
+                        : '0 probleme';
+                    addLog(`Pagina ${pageIndex} pare goală (${hint}). Reîncerc în ${delay / 1000}s...`);
+                    setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+                    return;
+                }
+                const hint = Number.isFinite(totalProblems)
+                    ? `Pagina ${pageIndex} goală deși totalul este ${totalProblems}`
+                    : `Pagina ${pageIndex} goală`;
+                finishScan({ complete: false, reason: hint });
+                return;
+            }
+
+            stats.pages++;
+
+            let pageSolved = 0;
+            let pageTried = 0;
+            let pageUnattempted = 0;
             let totalCount = 0;
-            let unknownScoreCount = 0;
+            let parseFailCount = 0;
+
             for (let card of cards) {
                 const codeEl = card.querySelector('code');
                 if (!codeEl) continue;
@@ -355,49 +546,56 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 let source = '';
                 const srcBlock = card.querySelector('blockquote[title="Sursa problemei"]');
                 if (srcBlock) source = srcBlock.innerText.trim();
-                const { userScore, maxScore } = extractScoreInfo(card);
-                if (userScore == null) unknownScoreCount++;
-                let score = userScore;
-                if (!Number.isFinite(score)) score = 0;
-                const solvedThreshold = Number.isFinite(maxScore) ? maxScore : 100;
-                if (score >= solvedThreshold && userScore != null) {
-                    solvedCount++;
+                const scoreInfo = extractScoreInfoFromCard(card);
+                const status = classifyProblemStatus(scoreInfo);
+
+                if (scoreInfo.candidates.length === 0) parseFailCount++;
+                if (status === 'solved') {
+                    pageSolved++;
+                    stats.solved++;
+                } else if (status === 'tried') {
+                    pageTried++;
+                    stats.tried++;
                 } else {
-                    if (isNaN(score)) score = 0;
-                    problems.push({ cnt: problems.length + 1, id, name, link, difficulty, score, postedBy_link: pbLink, postedBy_name: pbName, postedBy_img: pbImg, author, source });
+                    pageUnattempted++;
+                    stats.unattempted++;
                 }
-            }
-            if (cards.length === 0) {
-                // no more pages, show results
-                updateTable();
-                document.body.appendChild(table);
-                // list unsolved problems
-                if (problems.length > 0) {
-                    const listDiv = document.createElement('div');
-                    listDiv.style.marginTop = '1em';
-                    listDiv.innerHTML = '<h3>Lista problemelor nerezolvate:</h3>';
-                    const ul = document.createElement('ul');
-                    ul.style.listStyle = 'none';
-                    ul.style.paddingLeft = '0';
-                    problems.forEach(p => {
-                        const li = document.createElement('li');
-                        li.style.marginBottom = '0.25em';
-                        li.innerHTML = `<a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a>`;
-                        ul.appendChild(li);
+                stats.total++;
+
+                if (status !== 'solved') {
+                    const scoreKnown = scoreInfo.userScore != null && Number.isFinite(scoreInfo.userScore);
+                    const score = scoreKnown ? scoreInfo.userScore : 0;
+                    problems.push({
+                        cnt: problems.length + 1,
+                        id,
+                        name,
+                        link,
+                        difficulty,
+                        score,
+                        scoreKnown,
+                        status,
+                        postedBy_link: pbLink,
+                        postedBy_name: pbName,
+                        postedBy_img: pbImg,
+                        author,
+                        source,
                     });
-                    listDiv.appendChild(ul);
-                    document.body.appendChild(listDiv);
                 }
-                addLog(`<u>Am terminat de extras problemele.</u> Sunt ${problems.length} probleme nerezolvate. Tabelul și lista au fost adăugate mai jos.`);
-                return;
-            } else {
-                const unknownSuffix = unknownScoreCount > 0 ? ` (punctaj indisponibil pentru ${unknownScoreCount})` : '';
-                addLog(`Pagina ${pageIndex} are ${solvedCount}/${totalCount} probleme rezolvate.${unknownSuffix}`);
-                if (pageIndex === 1 && totalCount > 0 && unknownScoreCount === totalCount) {
-                    addLog(`<span style="color:#b35c00;"><b>Atenție:</b> nu pare să fie disponibil punctajul tău pe această listă. Verifică dacă ești autentificat pe pbinfo.ro.</span>`);
+
+                if (shouldDebugDump(id) && (scoreInfo.candidates.length === 0 || status === 'unattempted')) {
+                    debugDumpCard(card, { id, name, link, scoreInfo });
                 }
-                fetchPage(pageIndex + 1, 0);
             }
+
+            const scoreUnavailable = pageUnattempted === totalCount;
+            const scoreWarning = scoreUnavailable ? ' (punctaj indisponibil pentru toate)' : '';
+            const parseFailSuffix = parseFailCount > 0 ? ` · parseFail=${parseFailCount}` : '';
+            addLog(`Pagina ${pageIndex}: rezolvate ${pageSolved}, încercate ${pageTried}, neîncercate ${pageUnattempted} (total ${totalCount})${scoreWarning}${parseFailSuffix}.`);
+            if (pageIndex === 1 && totalCount > 0 && scoreUnavailable) {
+                addLog(`<span style="color:#b35c00;"><b>Atenție:</b> nu pare să fie disponibil punctajul tău pe această listă. Verifică dacă ești autentificat pe pbinfo.ro.</span>`);
+            }
+
+            fetchPage(pageIndex + 1, 0);
         };
         xhr.ontimeout = () => {
             if (retryCount < maxRetriesPerPage) {
@@ -406,7 +604,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
                 return;
             }
-            addLog(`Timeout la pagina ${pageIndex}. Oprire.`);
+            finishScan({ complete: false, reason: `Timeout la pagina ${pageIndex}` });
         };
         xhr.onerror = () => {
             if (retryCount < maxRetriesPerPage) {
@@ -415,7 +613,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
                 return;
             }
-            addLog(`Eroare de rețea la pagina ${pageIndex}. Oprire.`);
+            finishScan({ complete: false, reason: `Eroare de rețea la pagina ${pageIndex}` });
         };
         xhr.send();
     })(1, 0);

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -4,6 +4,77 @@
 // Use this script in the browser console on pbinfo.ro, providing either a
 // category URL or the global problems list URL when prompted.
 
+function normalizeSpace(str) {
+    return (str || '').toString().replace(/\s+/g, ' ').trim();
+}
+
+function normalizeForMatch(str) {
+    return normalizeSpace(str)
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase();
+}
+
+function parseScoreText(text) {
+    const t = normalizeSpace(text);
+    if (!t) return null;
+    const ratio = /(\d{1,3})\s*\/\s*(\d{1,3})/.exec(t);
+    if (ratio) {
+        return { value: parseInt(ratio[1], 10), max: parseInt(ratio[2], 10), hasRatio: true };
+    }
+    const pct = /(\d{1,3})\s*%/.exec(t);
+    if (pct) {
+        return { value: parseInt(pct[1], 10), max: 100, hasRatio: false };
+    }
+    const num = /(\d{1,3})/.exec(t);
+    if (!num) return null;
+    return { value: parseInt(num[1], 10), max: null, hasRatio: false };
+}
+
+function selectScoreFromCandidates(candidates) {
+    const userHints = ['obtinut', 'realizat', 'utilizator', 'user', 'tau'];
+    const maxHints = ['maxim', 'max'];
+
+    const isMaxCand = (c) => maxHints.some(h => normalizeForMatch(c.tooltip).includes(h) || normalizeForMatch(c.text).includes(h));
+    const isUserCand = (c) => userHints.some(h => normalizeForMatch(c.tooltip).includes(h) || normalizeForMatch(c.text).includes(h));
+
+    let maxScore = null;
+    for (const c of candidates) {
+        if (isMaxCand(c) && Number.isFinite(c.value)) {
+            maxScore = c.value;
+            break;
+        }
+    }
+
+    const nonMaxCandidates = candidates.filter(c => !isMaxCand(c));
+    if (nonMaxCandidates.length === 0) {
+        return { userScore: null, maxScore };
+    }
+
+    const ranked = nonMaxCandidates
+        .map(c => {
+            let rank = 0;
+            if (isUserCand(c)) rank += 100;
+            if (c.hasRatio) rank += 50;
+            if (c.isLink) rank += 10;
+            return { c, rank };
+        })
+        .sort((a, b) => b.rank - a.rank);
+
+    const best = ranked[0]?.c;
+    if (!best || !Number.isFinite(best.value)) {
+        return { userScore: null, maxScore };
+    }
+
+    if (best.max != null && Number.isFinite(best.max)) maxScore = best.max;
+    return { userScore: best.value, maxScore };
+}
+
+if (typeof window === 'undefined' || typeof document === 'undefined') {
+    if (typeof module !== 'undefined') {
+        module.exports = { normalizeSpace, normalizeForMatch, parseScoreText, selectScoreFromCandidates };
+    }
+} else {
 (function () {
     // restore console
     var iFrame = document.createElement('iframe');
@@ -56,6 +127,7 @@
     document.body.appendChild(reqPageEl);
 
     const problems = [];
+    const seenProblemIds = new Set();
     const sorted = { cnt: 1, id: 0, score: 0, difficulty: 0, postedBy_name: 0, author: 0, source: 0 };
     const table = document.createElement('table');
     table.style.width = '75%';
@@ -133,22 +205,104 @@
         });
     }
 
+    const tooltipAttrs = ['title', 'data-bs-title', 'data-bs-original-title', 'data-original-title'];
+    function getTooltipText(el) {
+        for (const attr of tooltipAttrs) {
+            const v = el.getAttribute(attr);
+            if (v) return v;
+        }
+        return '';
+    }
+
+    function extractScoreInfo(card) {
+        const candidates = [];
+
+        const tooltipEls = Array.from(card.querySelectorAll('[title],[data-bs-title],[data-bs-original-title],[data-original-title]'));
+        for (const el of tooltipEls) {
+            const tooltip = normalizeForMatch(getTooltipText(el));
+            if (!tooltip) continue;
+            if (!tooltip.includes('punctaj') && !tooltip.includes('scor') && !tooltip.includes('score')) continue;
+
+            const text = normalizeSpace(el.textContent);
+            const parsed = parseScoreText(text);
+            if (!parsed) continue;
+
+            candidates.push({
+                el,
+                tooltip: getTooltipText(el),
+                text,
+                value: parsed.value,
+                max: parsed.max,
+                hasRatio: parsed.hasRatio,
+                isLink: el.tagName === 'A',
+            });
+        }
+
+        if (candidates.length === 0) {
+            const badgeEls = Array.from(card.querySelectorAll('span.badge, a.badge, div.badge'))
+                .filter(el => !normalizeSpace(el.textContent).startsWith('#'));
+            for (const el of badgeEls) {
+                const text = normalizeSpace(el.textContent);
+                const parsed = parseScoreText(text);
+                if (!parsed) continue;
+                if (!/\bp\b/i.test(text) && !parsed.hasRatio) continue;
+                candidates.push({
+                    el,
+                    tooltip: getTooltipText(el),
+                    text,
+                    value: parsed.value,
+                    max: parsed.max,
+                    hasRatio: parsed.hasRatio,
+                    isLink: el.tagName === 'A',
+                });
+            }
+        }
+
+        return selectScoreFromCandidates(candidates);
+    }
+
     // Fetch pages recursively
-    (function fetchPage(pageIndex) {
+    const maxRetriesPerPage = 3;
+    (function fetchPage(pageIndex, retryCount = 0) {
         const xhr = new XMLHttpRequest();
         const url = pageLink + (pageLink.includes('?') ? '&' : '?') + 'start=' + 10 * (pageIndex - 1);
         xhr.open('GET', url);
-        xhr.setRequestHeader('Content-Type', 'text/plain');
+        xhr.timeout = 30000;
         xhr.onload = () => {
-            reqPageEl.innerHTML = xhr.response;
+            const responseText = xhr.responseText || xhr.response || '';
+            if (xhr.status !== 200) {
+                if (retryCount < maxRetriesPerPage) {
+                    const delay = 1000 * (retryCount + 1);
+                    addLog(`Eroare la pagina ${pageIndex} (status ${xhr.status}). Reîncerc în ${delay / 1000}s...`);
+                    setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+                    return;
+                }
+                addLog(`Eroare la pagina ${pageIndex} (status ${xhr.status}). Oprire.`);
+                return;
+            }
+
+            if (/invalid request/i.test(responseText)) {
+                if (retryCount < maxRetriesPerPage) {
+                    const delay = 1000 * (retryCount + 1);
+                    addLog(`Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
+                    setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+                    return;
+                }
+                addLog(`Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}. Oprire.`);
+                return;
+            }
+
+            reqPageEl.innerHTML = responseText;
             const cards = reqPageEl.querySelectorAll('div.card.mb-3');
             let solvedCount = 0;
             let totalCount = 0;
+            let unknownScoreCount = 0;
             for (let card of cards) {
                 const codeEl = card.querySelector('code');
                 if (!codeEl) continue;
                 const id = parseInt(codeEl.innerText.trim().slice(1));
-                if (problems.some(p => p.id === id)) continue;
+                if (seenProblemIds.has(id)) continue;
+                seenProblemIds.add(id);
                 totalCount++;
                 // name and link
                 let name = '';
@@ -192,14 +346,12 @@
                 let source = '';
                 const srcBlock = card.querySelector('blockquote[title="Sursa problemei"]');
                 if (srcBlock) source = srcBlock.innerText.trim();
-                // score
-                let score = 0;
-                const scoreEl = card.querySelector('span[title*="Punctaj"]');
-                if (scoreEl) {
-                    const m = /([0-9]+)/.exec(scoreEl.innerText);
-                    if (m) score = parseInt(m[1]);
-                }
-                if (score === 100) {
+                const { userScore, maxScore } = extractScoreInfo(card);
+                if (userScore == null) unknownScoreCount++;
+                let score = userScore;
+                if (!Number.isFinite(score)) score = 0;
+                const solvedThreshold = Number.isFinite(maxScore) ? maxScore : 100;
+                if (score >= solvedThreshold && userScore != null) {
                     solvedCount++;
                 } else {
                     if (isNaN(score)) score = 0;
@@ -230,10 +382,30 @@
                 addLog(`<u>Am terminat de extras problemele.</u> Sunt ${problems.length} probleme nerezolvate. Tabelul și lista au fost adăugate mai jos.`);
                 return;
             } else {
-                addLog(`Pagina ${pageIndex} are ${solvedCount}/${totalCount} probleme rezolvate.`);
-                fetchPage(pageIndex + 1);
+                const unknownSuffix = unknownScoreCount > 0 ? ` (punctaj indisponibil pentru ${unknownScoreCount})` : '';
+                addLog(`Pagina ${pageIndex} are ${solvedCount}/${totalCount} probleme rezolvate.${unknownSuffix}`);
+                fetchPage(pageIndex + 1, 0);
             }
         };
+        xhr.ontimeout = () => {
+            if (retryCount < maxRetriesPerPage) {
+                const delay = 1000 * (retryCount + 1);
+                addLog(`Timeout la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
+                setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+                return;
+            }
+            addLog(`Timeout la pagina ${pageIndex}. Oprire.`);
+        };
+        xhr.onerror = () => {
+            if (retryCount < maxRetriesPerPage) {
+                const delay = 1000 * (retryCount + 1);
+                addLog(`Eroare de rețea la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
+                setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
+                return;
+            }
+            addLog(`Eroare de rețea la pagina ${pageIndex}. Oprire.`);
+        };
         xhr.send();
-    })(1);
+    })(1, 0);
 })();
+}

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -650,6 +650,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     function normalizeScanMode(value) {
       const v = normalizeForMatch(value || '');
+      if (v === '1') return 'list';
+      if (v === '2') return 'id-range';
       if (v.includes('id')) return 'id-range';
       if (v.includes('range')) return 'id-range';
       if (v.includes('index')) return 'id-range';
@@ -660,21 +662,25 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     const defaultLink = location?.href || '';
     const modeFromWindow = normalizeScanMode(window.PBINFO_GET_UNSOLVED_MODE);
     let scanMode = modeFromWindow;
-    if (!scanMode) {
+    const modePromptDisabled = window.PBINFO_GET_UNSOLVED_MODE_PROMPT === false;
+    if (!modePromptDisabled) {
+      const defaultModePromptValue = modeFromWindow === 'id-range' ? '2' : '1';
       let modeInput = prompt(
         'Mod scanare:\n' +
           '1 = listă (paginare)\n' +
           '2 = interval ID (probleme/ID)\n' +
-          'Enter = 1',
-        '1'
+          `Enter = ${defaultModePromptValue}`,
+        defaultModePromptValue
       );
       if (modeInput === null) {
         console.warn('Nu a fost selectat un mod de scanare. Scriptul a fost oprit.');
         return;
       }
       modeInput = normalizeSpace(modeInput);
-      scanMode = modeInput === '2' ? 'id-range' : 'list';
+      scanMode = normalizeScanMode(modeInput) || (modeInput === '' ? null : 'list');
+      if (!scanMode) scanMode = modeFromWindow || 'list';
     }
+    if (!scanMode) scanMode = 'list';
     config.scanMode = scanMode;
 
     function parseIdRangeInput(value, fallback) {

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -762,6 +762,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       updateList(visible);
     }
 
+    let renderTimer = null;
+    function requestRenderResults() {
+      if (renderTimer != null) clearTimeout(renderTimer);
+      renderTimer = setTimeout(() => {
+        renderTimer = null;
+        renderResults();
+      }, 150);
+    }
+
     function downloadText(filename, content, mime) {
       const blob = new Blob([content], { type: mime || 'text/plain;charset=utf-8' });
       const url = URL.createObjectURL(blob);
@@ -845,7 +854,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       minInput.addEventListener('input', () => {
         const v = Number(minInput.value);
         filterState.scoreMin = Number.isFinite(v) && minInput.value !== '' ? v : null;
-        renderResults();
+        requestRenderResults();
       });
       minLabel.appendChild(minInput);
       groupScore.appendChild(minLabel);
@@ -859,7 +868,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       maxInput.addEventListener('input', () => {
         const v = Number(maxInput.value);
         filterState.scoreMax = Number.isFinite(v) && maxInput.value !== '' ? v : null;
-        renderResults();
+        requestRenderResults();
       });
       maxLabel.appendChild(maxInput);
       groupScore.appendChild(maxLabel);

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -155,6 +155,78 @@ function parseTotalProblems(html) {
     return Number.isFinite(n) ? n : null;
 }
 
+function normalizeListUrl(inputUrl, baseUrl, paginationParam = 'start') {
+    const raw = normalizeSpace(inputUrl);
+    const base = normalizeSpace(baseUrl);
+    if (!raw && !base) return null;
+    let u;
+    try {
+        u = new URL(raw || base, base || undefined);
+    } catch {
+        return null;
+    }
+    u.searchParams.delete(paginationParam);
+    return u.toString();
+}
+
+function buildPageUrl(
+    baseUrl,
+    { pageIndex, pageSize, mode = 'offset', param = 'start', pageBase = 1 }
+) {
+    if (!baseUrl) return null;
+    const u = new URL(baseUrl);
+    if (mode === 'page') {
+        const base = Number.isFinite(pageBase) ? pageBase : 1;
+        u.searchParams.set(param, String(base + (pageIndex - 1)));
+        return u.toString();
+    }
+    const size = Number.isFinite(pageSize) ? pageSize : 10;
+    u.searchParams.set(param, String(size * (pageIndex - 1)));
+    return u.toString();
+}
+
+function csvEscape(value) {
+    if (value == null) return '';
+    const s = String(value);
+    const needsQuotes = /[",\n]/.test(s);
+    const escaped = s.replace(/"/g, '""');
+    return needsQuotes ? `"${escaped}"` : escaped;
+}
+
+function problemsToCsv(problems) {
+    const headers = [
+        'id',
+        'name',
+        'status',
+        'userScore',
+        'maxScore',
+        'difficulty',
+        'postedBy',
+        'author',
+        'source',
+        'link',
+    ];
+    const rows = Array.isArray(problems)
+        ? problems.map(p => ({
+            id: p.id,
+            name: p.name,
+            status: p.status,
+            userScore: p.userScore,
+            maxScore: p.maxScore,
+            difficulty: p.difficulty,
+            postedBy: p.postedBy_name,
+            author: p.author,
+            source: p.source,
+            link: p.link,
+        }))
+        : [];
+    const lines = [headers.join(',')].concat(
+        rows.map(r => headers.map(h => csvEscape(r[h])).join(','))
+    );
+    // Add UTF-8 BOM so Excel keeps diacritics.
+    return `\ufeff${lines.join('\n')}`;
+}
+
 if (typeof window === 'undefined' || typeof document === 'undefined') {
     if (typeof module !== 'undefined') {
         module.exports = {
@@ -167,6 +239,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             extractScoreInfoFromCard,
             classifyProblemStatus,
             parseTotalProblems,
+            normalizeListUrl,
+            buildPageUrl,
+            problemsToCsv,
         };
     }
 } else {
@@ -178,15 +253,65 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     window.console = iFrame.contentWindow.console;
     console.clear();
 
-    // prompt for link
-    let pageLink = prompt('Pune un link către lista de probleme de unde vrei să obții problemele nerezolvate.\n' +
-        'Mergi la o clasă/categorie sau la pagina generală a problemelor și copiază link-ul aici.');
-    if (!pageLink) {
+    const config = {
+        pagination: {
+            mode: window.PBINFO_GET_UNSOLVED_PAGINATION_MODE || 'offset',
+            param: window.PBINFO_GET_UNSOLVED_PAGE_PARAM || 'start',
+            pageBase: Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_PAGE_BASE))
+                ? Number(window.PBINFO_GET_UNSOLVED_PAGE_BASE)
+                : 1,
+        },
+        pageSize: Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_PAGE_SIZE))
+            ? Number(window.PBINFO_GET_UNSOLVED_PAGE_SIZE)
+            : null,
+        concurrency: Math.max(
+            1,
+            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_CONCURRENCY))
+                ? Number(window.PBINFO_GET_UNSOLVED_CONCURRENCY)
+                : 1
+        ),
+        delayMs: Math.max(
+            0,
+            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_DELAY_MS))
+                ? Number(window.PBINFO_GET_UNSOLVED_DELAY_MS)
+                : 0
+        ),
+        timeoutMs: Math.max(
+            1000,
+            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_TIMEOUT_MS))
+                ? Number(window.PBINFO_GET_UNSOLVED_TIMEOUT_MS)
+                : 30000
+        ),
+        maxRetriesPerPage: Math.max(
+            0,
+            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_MAX_RETRIES))
+                ? Number(window.PBINFO_GET_UNSOLVED_MAX_RETRIES)
+                : 3
+        ),
+        maxPages: Math.max(
+            1,
+            Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_MAX_PAGES))
+                ? Number(window.PBINFO_GET_UNSOLVED_MAX_PAGES)
+                : 5000
+        ),
+    };
+
+    const defaultLink = location?.href || '';
+    let pageLinkInput = prompt(
+        'Pune un link către lista de probleme de unde vrei să obții problemele nerezolvate.\n' +
+            'Enter = pagina curentă. Dacă folosești filtre, copiază link-ul din bara de adrese.',
+        defaultLink
+    );
+    if (pageLinkInput === null) {
         console.warn('Nu a fost furnizat niciun link. Scriptul a fost oprit.');
         return;
     }
-    // strip existing start parameter
-    pageLink = pageLink.replace(/([?&])start=\d+/g, '');
+    pageLinkInput = normalizeSpace(pageLinkInput);
+    const pageLink = normalizeListUrl(pageLinkInput || defaultLink, defaultLink, config.pagination.param);
+    if (!pageLink) {
+        console.warn('Link invalid. Scriptul a fost oprit.');
+        return;
+    }
 
     // wipe the page and setup UI
     document.head.innerHTML = '';
@@ -198,7 +323,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     document.body.appendChild(title);
 
     const style = document.createElement('style');
-    style.innerHTML = `a:hover{cursor:pointer;} td{border:1px solid black;}`;
+    style.innerHTML = `
+        :root { font-family: Arial, sans-serif; }
+        a:hover{cursor:pointer;}
+        td{border:1px solid black;padding:0.25em 0.4em;vertical-align:top;}
+        table{border-collapse:collapse;}
+        #controls{margin:0.75em 0 0.5em;display:flex;flex-wrap:wrap;gap:0.75em;align-items:flex-end;}
+        #controls .group{display:flex;flex-direction:column;gap:0.25em;min-width:12em;}
+        #controls label{display:flex;gap:0.4em;align-items:center;user-select:none;}
+        #controls input[type="number"]{width:8em;}
+        #controls button{padding:0.3em 0.6em;}
+        #progress{margin:0.4em 0 0.2em;color:#444;}
+        #summary{margin:0.5em 0;color:#333;}
+        .pill{display:inline-block;padding:0.1em 0.4em;border-radius:0.4em;color:white;}
+        .muted{color:#666;}
+    `;
     document.head.appendChild(style);
 
     const logDiv = document.createElement('div');
@@ -217,7 +356,23 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     addLog('Link către lista de probleme: <a href="' + pageLink + '"><i>' + pageLink + '</i></a>');
 
-    const pageSize = 10;
+    const progressDiv = document.createElement('div');
+    progressDiv.id = 'progress';
+    document.body.appendChild(progressDiv);
+
+    const controlsDiv = document.createElement('div');
+    controlsDiv.id = 'controls';
+    document.body.appendChild(controlsDiv);
+
+    const summaryDiv = document.createElement('div');
+    summaryDiv.id = 'summary';
+    document.body.appendChild(summaryDiv);
+
+    let pageSize = config.pageSize;
+    let totalProblems = null;
+    let totalPages = null;
+    const startedAt = Date.now();
+
     const stats = { solved: 0, tried: 0, unattempted: 0, total: 0, pages: 0 };
     let finished = false;
 
@@ -282,13 +437,20 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         }
     }
 
-    const reqPageEl = document.createElement('div');
-    reqPageEl.style.display = 'none';
-    document.body.appendChild(reqPageEl);
-
-    const problems = [];
+    const allProblems = [];
     const seenProblemIds = new Set();
     const sorted = { cnt: 1, id: 0, score: 0, status: 0, difficulty: 0, postedBy_name: 0, author: 0, source: 0 };
+
+    const filterState = {
+        statuses: new Set(['tried', 'unattempted']),
+        includeUnknownScore: true,
+        scoreMin: null,
+        scoreMax: null,
+    };
+
+    const listDiv = document.createElement('div');
+    listDiv.style.marginTop = '1em';
+
     const table = document.createElement('table');
     table.style.width = '75%';
     table.style.minWidth = '450px';
@@ -326,12 +488,215 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         } else {
             sorted[type] *= -1;
         }
-        quickSort(problems, 0, problems.length - 1, type);
-        if (sorted[type] === -1) problems.reverse();
-        updateTable();
+        quickSort(allProblems, 0, allProblems.length - 1, type);
+        if (sorted[type] === -1) allProblems.reverse();
+        renderResults();
     }
 
-    function updateTable() {
+    window.sortTable = sortTable;
+
+    function getVisibleProblems() {
+        const min = Number.isFinite(filterState.scoreMin) ? filterState.scoreMin : null;
+        const max = Number.isFinite(filterState.scoreMax) ? filterState.scoreMax : null;
+        const includeUnknown = Boolean(filterState.includeUnknownScore);
+        const statuses = filterState.statuses;
+
+        return allProblems.filter(p => {
+            if (!statuses.has(p.status)) return false;
+            const scoreKnown = p.userScore != null && Number.isFinite(p.userScore);
+            if (!scoreKnown) return includeUnknown;
+            if (min != null && p.userScore < min) return false;
+            if (max != null && p.userScore > max) return false;
+            return true;
+        });
+    }
+
+    function updateSummary(visible) {
+        const shown = visible.length;
+        const total = allProblems.length;
+        const unsolved = allProblems.filter(p => p.status !== 'solved').length;
+        summaryDiv.innerHTML = `<b>Statistici:</b> scanate=${total} · nerezolvate=${unsolved} · afișate=${shown} · pagini=${stats.pages}`;
+    }
+
+    function updateList(visible) {
+        const tried = visible.filter(p => p.status === 'tried');
+        const unattempted = visible.filter(p => p.status === 'unattempted');
+        const solved = visible.filter(p => p.status === 'solved');
+
+        function mkList(items) {
+            if (items.length === 0) return '<span class="muted">-</span>';
+            return `<ul style="list-style:none;padding-left:0;margin:0;">${items
+                .map(p => `<li style="margin:0.15em 0;"><a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a></li>`)
+                .join('')}</ul>`;
+        }
+
+        listDiv.innerHTML = `<h3>Lista (filtrată):</h3>
+            <div style="margin-bottom:0.5em;">
+                Încercate: <b>${tried.length}</b> · Neîncercate: <b>${unattempted.length}</b> · Rezolvate: <b>${solved.length}</b>
+            </div>
+            <h4 style="margin:0.75em 0 0.25em;">Încercate</h4>
+            ${mkList(tried)}
+            <h4 style="margin:0.75em 0 0.25em;">Neîncercate</h4>
+            ${mkList(unattempted)}
+            <h4 style="margin:0.75em 0 0.25em;">Rezolvate</h4>
+            ${mkList(solved)}`;
+    }
+
+    function renderResults() {
+        const visible = getVisibleProblems();
+        updateTable(visible);
+        updateSummary(visible);
+        updateList(visible);
+    }
+
+    function downloadText(filename, content, mime) {
+        const blob = new Blob([content], { type: mime || 'text/plain;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+    }
+
+    function setupControls() {
+        const groupStatus = document.createElement('div');
+        groupStatus.className = 'group';
+        groupStatus.innerHTML = '<b>Stare</b>';
+
+        const statuses = [
+            { key: 'solved', label: 'rezolvate' },
+            { key: 'tried', label: 'încercate' },
+            { key: 'unattempted', label: 'neîncercate' },
+        ];
+
+        for (const s of statuses) {
+            const label = document.createElement('label');
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.checked = filterState.statuses.has(s.key);
+            input.addEventListener('change', () => {
+                if (input.checked) filterState.statuses.add(s.key);
+                else filterState.statuses.delete(s.key);
+                renderResults();
+            });
+            label.appendChild(input);
+            label.appendChild(document.createTextNode(` ${s.label}`));
+            groupStatus.appendChild(label);
+        }
+
+        const groupScore = document.createElement('div');
+        groupScore.className = 'group';
+        groupScore.innerHTML = '<b>Filtru punctaj</b>';
+
+        const minLabel = document.createElement('label');
+        minLabel.textContent = 'Min';
+        const minInput = document.createElement('input');
+        minInput.type = 'number';
+        minInput.min = '0';
+        minInput.placeholder = '-';
+        minInput.addEventListener('input', () => {
+            const v = Number(minInput.value);
+            filterState.scoreMin = Number.isFinite(v) && minInput.value !== '' ? v : null;
+            renderResults();
+        });
+        minLabel.appendChild(minInput);
+        groupScore.appendChild(minLabel);
+
+        const maxLabel = document.createElement('label');
+        maxLabel.textContent = 'Max';
+        const maxInput = document.createElement('input');
+        maxInput.type = 'number';
+        maxInput.min = '0';
+        maxInput.placeholder = '-';
+        maxInput.addEventListener('input', () => {
+            const v = Number(maxInput.value);
+            filterState.scoreMax = Number.isFinite(v) && maxInput.value !== '' ? v : null;
+            renderResults();
+        });
+        maxLabel.appendChild(maxInput);
+        groupScore.appendChild(maxLabel);
+
+        const unknownLabel = document.createElement('label');
+        const unknownInput = document.createElement('input');
+        unknownInput.type = 'checkbox';
+        unknownInput.checked = filterState.includeUnknownScore;
+        unknownInput.addEventListener('change', () => {
+            filterState.includeUnknownScore = unknownInput.checked;
+            renderResults();
+        });
+        unknownLabel.appendChild(unknownInput);
+        unknownLabel.appendChild(document.createTextNode(' include scor necunoscut'));
+        groupScore.appendChild(unknownLabel);
+
+        const groupExport = document.createElement('div');
+        groupExport.className = 'group';
+        groupExport.innerHTML = '<b>Export</b>';
+
+        const exportCsv = document.createElement('button');
+        exportCsv.textContent = 'CSV (filtrat)';
+        exportCsv.addEventListener('click', () => {
+            const visible = getVisibleProblems();
+            downloadText('pbinfo-problems.csv', problemsToCsv(visible), 'text/csv;charset=utf-8');
+        });
+        groupExport.appendChild(exportCsv);
+
+        const exportJson = document.createElement('button');
+        exportJson.textContent = 'JSON (filtrat)';
+        exportJson.addEventListener('click', () => {
+            const visible = getVisibleProblems();
+            const data = visible.map(p => ({
+                id: p.id,
+                name: p.name,
+                link: p.link,
+                status: p.status,
+                userScore: p.userScore,
+                maxScore: p.maxScore,
+                difficulty: p.difficulty,
+                postedBy_name: p.postedBy_name,
+                postedBy_link: p.postedBy_link,
+                author: p.author,
+                source: p.source,
+            }));
+            downloadText('pbinfo-problems.json', JSON.stringify(data, null, 2), 'application/json;charset=utf-8');
+        });
+        groupExport.appendChild(exportJson);
+
+        controlsDiv.replaceChildren(groupStatus, groupScore, groupExport);
+    }
+
+    function formatDuration(ms) {
+        const s = Math.max(0, Math.floor(ms / 1000));
+        const h = Math.floor(s / 3600);
+        const m = Math.floor((s % 3600) / 60);
+        const ss = s % 60;
+        if (h > 0) return `${h}h ${String(m).padStart(2, '0')}m ${String(ss).padStart(2, '0')}s`;
+        if (m > 0) return `${m}m ${String(ss).padStart(2, '0')}s`;
+        return `${ss}s`;
+    }
+
+    function updateProgress(inFlight) {
+        const elapsedMs = Date.now() - startedAt;
+        const pagesDone = stats.pages;
+        const pagesText = Number.isFinite(totalPages) ? `${pagesDone}/${totalPages}` : `${pagesDone}`;
+        const probsText = Number.isFinite(totalProblems) ? `${stats.total}/${totalProblems}` : `${stats.total}`;
+        const speed = elapsedMs > 0 ? pagesDone / (elapsedMs / 1000) : 0;
+        const etaMs =
+            Number.isFinite(totalPages) && speed > 0 ? ((totalPages - pagesDone) / speed) * 1000 : null;
+        const etaText = etaMs != null ? ` · ETA ~${formatDuration(etaMs)}` : '';
+        const inflightText = inFlight > 0 ? ` · în lucru ${inFlight}` : '';
+        progressDiv.textContent = `Progres: pagini ${pagesText}, probleme ${probsText} · timp ${formatDuration(
+            elapsedMs
+        )}${etaText}${inflightText}`;
+    }
+
+    setupControls();
+    renderResults();
+    updateProgress(0);
+
+    function updateTable(visibleProblems) {
         function sortSymbol(t) {
             if (sorted[t] === 1) return '&#9660;';
             if (sorted[t] === -1) return '&#9650;';
@@ -363,14 +728,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             <td style="min-width:10em;user-select:none;"><a onclick="sortTable('author')">Autor ${sortSymbol('author')}</a></td>
             <td style="min-width:10em;user-select:none;"><a onclick="sortTable('source')">Sursa problemei ${sortSymbol('source')}</a></td>
         </tr>`;
-        problems.forEach(p => {
+        const list = Array.isArray(visibleProblems) ? visibleProblems : getVisibleProblems();
+        list.forEach((p, i) => {
             const row = document.createElement('tr');
-            row.innerHTML = `<td>${p.cnt}.</td>
+            row.innerHTML = `<td>${i + 1}.</td>
                 <td><a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a></td>
-                <td>${p.scoreKnown ? `${p.score}p` : '-'}</td>
-                <td><span style="color:white;background-color:#${statusColor(p.status)};">${statusLabel(p.status)}</span></td>
-                <td><span style="color:white;background-color:#${difficultyColor(p.difficulty)};">${numberToDifficulty(p.difficulty)}</span></td>
-                <td><a target="_blank" href="${p.postedBy_link}"><img style="vertical-align:middle;width:1.1em;" src="${p.postedBy_img}"> ${p.postedBy_name}</a></td>
+                <td>${p.userScore != null && Number.isFinite(p.userScore) ? `${p.userScore}p` : '-'}</td>
+                <td><span class="pill" style="background-color:#${statusColor(p.status)};">${statusLabel(p.status)}</span></td>
+                <td><span class="pill" style="background-color:#${difficultyColor(p.difficulty)};">${numberToDifficulty(p.difficulty)}</span></td>
+                <td>${p.postedBy_link ? `<a target="_blank" href="${p.postedBy_link}"><img style="vertical-align:middle;width:1.1em;" src="${p.postedBy_img}"> ${p.postedBy_name}</a>` : ''}</td>
                 <td>${p.author}</td>
                 <td>${p.source}</td>`;
             table.appendChild(row);
@@ -381,49 +747,16 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         if (finished) return;
         finished = true;
 
-        updateTable();
         document.body.appendChild(table);
-
-        const tried = problems.filter(p => p.status === 'tried');
-        const unattempted = problems.filter(p => p.status === 'unattempted');
-
-        const listDiv = document.createElement('div');
-        listDiv.style.marginTop = '1em';
-        listDiv.innerHTML = `<h3>Lista problemelor nerezolvate:</h3>
-            <div style="margin-bottom:0.5em;">
-                Încercate: <b>${tried.length}</b> · Neîncercate: <b>${unattempted.length}</b>
-            </div>`;
-
-        function appendList(titleText, items) {
-            if (items.length === 0) return;
-            const h = document.createElement('h4');
-            h.textContent = titleText;
-            h.style.margin = '0.75em 0 0.25em';
-            const ul = document.createElement('ul');
-            ul.style.listStyle = 'none';
-            ul.style.paddingLeft = '0';
-            items.forEach(p => {
-                const li = document.createElement('li');
-                li.style.marginBottom = '0.25em';
-                li.innerHTML = `<a href="${p.link}" target="_blank">#${p.id} - ${p.name}</a>`;
-                ul.appendChild(li);
-            });
-            listDiv.appendChild(h);
-            listDiv.appendChild(ul);
-        }
-
-        appendList('Încercate (punctaj < maxim)', tried);
-        appendList('Neîncercate (punctaj indisponibil)', unattempted);
-
-        if (tried.length + unattempted.length > 0) {
-            document.body.appendChild(listDiv);
-        }
+        document.body.appendChild(listDiv);
+        renderResults();
 
         const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, pagini ${stats.pages}).`;
         addLog(summary);
 
+        const unsolvedCount = allProblems.filter(p => p.status !== 'solved').length;
         if (complete) {
-            addLog(`<u>Am terminat de extras problemele.</u> Sunt ${problems.length} probleme nerezolvate. Tabelul și lista au fost adăugate mai jos.`);
+            addLog(`<u>Am terminat de extras problemele.</u> Sunt ${unsolvedCount} probleme nerezolvate. Tabelul și lista au fost adăugate mai jos.`);
             return;
         }
 
@@ -431,24 +764,77 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         addLog(`<span style="color:#b30000;"><u>Scanarea s-a oprit înainte de final.</u></span>${reasonText}`);
     }
 
-    // Fetch pages recursively
-    const maxRetriesPerPage = 3;
-    (function fetchPage(pageIndex, retryCount = 0) {
+    // Fetch pages (optional concurrency)
+    const maxRetriesPerPage = config.maxRetriesPerPage;
+    const pageQueue = [];
+    let queueInitialized = false;
+    let inFlight = 0;
+
+    function schedule(fn) {
+        if (config.delayMs > 0) setTimeout(fn, config.delayMs);
+        else fn();
+    }
+
+    function maybeFinish() {
         if (finished) return;
+        if (queueInitialized && pageQueue.length === 0 && inFlight === 0) {
+            finishScan({ complete: true });
+        }
+    }
+
+    function fetchNext() {
+        if (finished) return;
+        const next = pageQueue.shift();
+        if (next == null) {
+            maybeFinish();
+            return;
+        }
+        fetchPage(next, 0);
+    }
+
+    function initQueueFromTotalPages() {
+        if (queueInitialized) return;
+        if (!Number.isFinite(totalPages)) return;
+        for (let i = 2; i <= totalPages; i++) pageQueue.push(i);
+        queueInitialized = true;
+        const extraWorkers = Math.max(0, Math.min(config.concurrency, totalPages) - 1);
+        for (let i = 0; i < extraWorkers; i++) fetchNext();
+    }
+
+    function fetchPage(pageIndex, retryCount = 0) {
+        if (finished) return;
+        inFlight++;
+        updateProgress(inFlight);
         const xhr = new XMLHttpRequest();
-        const startOffset = pageSize * (pageIndex - 1);
-        const url = pageLink + (pageLink.includes('?') ? '&' : '?') + 'start=' + startOffset;
+        let finalized = false;
+        const finalize = () => {
+            if (finalized) return;
+            finalized = true;
+            inFlight = Math.max(0, inFlight - 1);
+            updateProgress(inFlight);
+        };
+        const effectivePageSize = Number.isFinite(pageSize) ? pageSize : 10;
+        const startOffset = effectivePageSize * (pageIndex - 1);
+        const url = buildPageUrl(pageLink, {
+            pageIndex,
+            pageSize: effectivePageSize,
+            mode: config.pagination.mode,
+            param: config.pagination.param,
+            pageBase: config.pagination.pageBase,
+        });
         xhr.open('GET', url);
-        xhr.timeout = 30000;
+        xhr.timeout = config.timeoutMs;
         xhr.onload = () => {
             const responseText = xhr.responseText || xhr.response || '';
             if (xhr.status !== 200) {
                 if (retryCount < maxRetriesPerPage) {
                     const delay = 1000 * (retryCount + 1);
                     addLog(`Eroare la pagina ${pageIndex} (status ${xhr.status}). Reîncerc în ${delay / 1000}s...`);
+                    finalize();
                     setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
                     return;
                 }
+                finalize();
                 finishScan({ complete: false, reason: `Eroare la pagina ${pageIndex} (status ${xhr.status})` });
                 return;
             }
@@ -457,34 +843,64 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 if (retryCount < maxRetriesPerPage) {
                     const delay = 1000 * (retryCount + 1);
                     addLog(`Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
+                    finalize();
                     setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
                     return;
                 }
+                finalize();
                 finishScan({ complete: false, reason: `Serverul a răspuns cu "Invalid request" la pagina ${pageIndex}` });
                 return;
             }
 
-            reqPageEl.innerHTML = responseText;
-            const cards = reqPageEl.querySelectorAll('div.card.mb-3');
+            const pageEl = document.createElement('div');
+            pageEl.innerHTML = responseText;
+            const cards = pageEl.querySelectorAll('div.card.mb-3');
+
+            if (pageIndex === 1) {
+                if (pageSize == null && cards.length > 0) {
+                    pageSize = cards.length;
+                    addLog(`Page size detectată automat: ${pageSize}.`);
+                }
+                if (totalProblems == null) {
+                    const t = parseTotalProblems(responseText);
+                    if (Number.isFinite(t)) totalProblems = t;
+                }
+                if (Number.isFinite(totalProblems) && Number.isFinite(pageSize)) {
+                    totalPages = Math.ceil(totalProblems / pageSize);
+                }
+                updateProgress(inFlight);
+                if (!queueInitialized && Number.isFinite(totalPages)) {
+                    addLog(`Total detectat: ${totalProblems} probleme · ${totalPages} pagini · pageSize=${pageSize} · concurență=${config.concurrency}.`);
+                    initQueueFromTotalPages();
+                }
+            }
 
             if (cards.length === 0) {
-                const totalProblems = parseTotalProblems(responseText);
-                if (Number.isFinite(totalProblems) && startOffset >= totalProblems) {
+                const t = totalProblems ?? parseTotalProblems(responseText);
+                if (Number.isFinite(t) && startOffset >= t) {
+                    finalize();
+                    if (queueInitialized) {
+                        pageQueue.length = 0;
+                        maybeFinish();
+                        return;
+                    }
                     finishScan({ complete: true });
                     return;
                 }
                 if (retryCount < maxRetriesPerPage) {
                     const delay = 1000 * (retryCount + 1);
-                    const hint = Number.isFinite(totalProblems)
-                        ? `0 probleme, dar total=${totalProblems}`
+                    const hint = Number.isFinite(t)
+                        ? `0 probleme, dar total=${t}`
                         : '0 probleme';
                     addLog(`Pagina ${pageIndex} pare goală (${hint}). Reîncerc în ${delay / 1000}s...`);
+                    finalize();
                     setTimeout(() => fetchPage(pageIndex, retryCount + 1), delay);
                     return;
                 }
-                const hint = Number.isFinite(totalProblems)
-                    ? `Pagina ${pageIndex} goală deși totalul este ${totalProblems}`
+                const hint = Number.isFinite(t)
+                    ? `Pagina ${pageIndex} goală deși totalul este ${t}`
                     : `Pagina ${pageIndex} goală`;
+                finalize();
                 finishScan({ complete: false, reason: hint });
                 return;
             }
@@ -535,7 +951,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                             const host = new URL(pbImg).hostname;
                             if (host === 'www.gravatar.com') pbImg = pbImg.replace(/&s=\d+/i, '&s=128');
                             else if (host === 'www.pbinfo.ro') pbImg = pbImg.replace(/&gsize=\d+/i, '&gsize=128');
-                        } catch (e) {}
+                        } catch {}
                     }
                 }
                 // author
@@ -562,25 +978,26 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 }
                 stats.total++;
 
-                if (status !== 'solved') {
-                    const scoreKnown = scoreInfo.userScore != null && Number.isFinite(scoreInfo.userScore);
-                    const score = scoreKnown ? scoreInfo.userScore : 0;
-                    problems.push({
-                        cnt: problems.length + 1,
-                        id,
-                        name,
-                        link,
-                        difficulty,
-                        score,
-                        scoreKnown,
-                        status,
-                        postedBy_link: pbLink,
-                        postedBy_name: pbName,
-                        postedBy_img: pbImg,
-                        author,
-                        source,
-                    });
-                }
+                const scoreKnown = scoreInfo.userScore != null && Number.isFinite(scoreInfo.userScore);
+                const maxScore = Number.isFinite(scoreInfo.maxScore) ? scoreInfo.maxScore : 100;
+                const score = scoreKnown ? scoreInfo.userScore : -1;
+                allProblems.push({
+                    cnt: allProblems.length + 1,
+                    id,
+                    name,
+                    link,
+                    difficulty,
+                    score,
+                    scoreKnown,
+                    userScore: scoreInfo.userScore,
+                    maxScore,
+                    status,
+                    postedBy_link: pbLink,
+                    postedBy_name: pbName,
+                    postedBy_img: pbImg,
+                    author,
+                    source,
+                });
 
                 if (shouldDebugDump(id) && (scoreInfo.candidates.length === 0 || status === 'unattempted')) {
                     debugDumpCard(card, { id, name, link, scoreInfo });
@@ -595,9 +1012,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 addLog(`<span style="color:#b35c00;"><b>Atenție:</b> nu pare să fie disponibil punctajul tău pe această listă. Verifică dacă ești autentificat pe pbinfo.ro.</span>`);
             }
 
-            fetchPage(pageIndex + 1, 0);
+            finalize();
+            if (queueInitialized) {
+                schedule(fetchNext);
+                return;
+            }
+            schedule(() => fetchPage(pageIndex + 1, 0));
         };
         xhr.ontimeout = () => {
+            finalize();
             if (retryCount < maxRetriesPerPage) {
                 const delay = 1000 * (retryCount + 1);
                 addLog(`Timeout la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
@@ -607,6 +1030,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             finishScan({ complete: false, reason: `Timeout la pagina ${pageIndex}` });
         };
         xhr.onerror = () => {
+            finalize();
             if (retryCount < maxRetriesPerPage) {
                 const delay = 1000 * (retryCount + 1);
                 addLog(`Eroare de rețea la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
@@ -616,6 +1040,8 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             finishScan({ complete: false, reason: `Eroare de rețea la pagina ${pageIndex}` });
         };
         xhr.send();
-    })(1, 0);
+    }
+
+    fetchPage(1, 0);
 })();
 }

--- a/pbinfo-get-unsolved-enhanced.js
+++ b/pbinfo-get-unsolved-enhanced.js
@@ -299,6 +299,65 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     window.console = iFrame.contentWindow.console;
     console.clear();
 
+    const STORAGE_NAMESPACE = 'pbinfo-get-unsolved';
+    const STATE_STORAGE_VERSION = 1;
+    const THEME_STORAGE_KEY = `${STORAGE_NAMESPACE}:theme`;
+
+    function safeJsonParse(value) {
+      if (typeof value !== 'string' || value.trim() === '') return null;
+      try {
+        return JSON.parse(value);
+      } catch {
+        return null;
+      }
+    }
+
+    function fnv1a32(str) {
+      const s = String(str || '');
+      let h = 0x811c9dc5;
+      for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i);
+        h = Math.imul(h, 0x01000193);
+      }
+      return (h >>> 0).toString(16).padStart(8, '0');
+    }
+
+    function makeStateKeys(pageLink) {
+      const h = fnv1a32(pageLink);
+      return {
+        full: `${STORAGE_NAMESPACE}:state:v${STATE_STORAGE_VERSION}:${h}`,
+        minimal: `${STORAGE_NAMESPACE}:state-min:v${STATE_STORAGE_VERSION}:${h}`,
+      };
+    }
+
+    function formatDateTime(ts) {
+      const d = new Date(Number(ts));
+      if (!Number.isFinite(d.getTime())) return '-';
+      return d.toLocaleString();
+    }
+
+    function loadThemePreference() {
+      try {
+        const v = normalizeSpace(localStorage.getItem(THEME_STORAGE_KEY));
+        if (v === 'light' || v === 'dark' || v === 'system') return v;
+      } catch {}
+      return 'system';
+    }
+
+    function persistThemePreference(value) {
+      try {
+        localStorage.setItem(THEME_STORAGE_KEY, value);
+      } catch {}
+    }
+
+    function applyThemePreference(value) {
+      const v = value === 'light' || value === 'dark' || value === 'system' ? value : 'system';
+      if (v === 'system') document.documentElement.removeAttribute('data-theme');
+      else document.documentElement.setAttribute('data-theme', v);
+      persistThemePreference(v);
+      return v;
+    }
+
     const config = {
       pagination: {
         mode: window.PBINFO_GET_UNSOLVED_PAGINATION_MODE || 'offset',
@@ -369,28 +428,91 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       return;
     }
 
-    let startPageInput = prompt(
-      'De la ce pagină să încep scanarea?\n' +
-        '1 = de la început. Pentru resume, pune un număr mai mare.\n' +
-        'Enter = valoarea default.',
-      String(config.startPage)
+    const stateKeys = makeStateKeys(pageLink);
+    const savedFull = safeJsonParse(
+      (() => {
+        try {
+          return localStorage.getItem(stateKeys.full);
+        } catch {
+          return null;
+        }
+      })()
     );
-    if (startPageInput === null) {
-      console.warn('Nu a fost furnizat start page. Scriptul a fost oprit.');
-      return;
+    const savedMinimal =
+      savedFull == null
+        ? safeJsonParse(
+            (() => {
+              try {
+                return localStorage.getItem(stateKeys.minimal);
+              } catch {
+                return null;
+              }
+            })()
+          )
+        : null;
+
+    let pendingRestore = null;
+    let restoreMode = null;
+    const candidate = savedFull || savedMinimal;
+    if (candidate && candidate.pageLink === pageLink) {
+      const savedAt = formatDateTime(candidate.savedAt);
+      const pages = Number.isFinite(candidate.stats?.pages) ? candidate.stats.pages : null;
+      const problems = Number.isFinite(candidate.stats?.total)
+        ? candidate.stats.total
+        : Array.isArray(candidate.problems)
+          ? candidate.problems.length
+          : null;
+      const kind = savedFull ? 'full' : 'minimal';
+      const note = kind === 'minimal' ? ' (doar progres, fără lista completă)' : '';
+      const ok = confirm(
+        `Am găsit un scan salvat pentru acest link${note}.\n` +
+          `Salvat la: ${savedAt}\n` +
+          `${pages != null ? `Pagini scanate: ${pages}\n` : ''}` +
+          `${problems != null ? `Probleme scanate: ${problems}\n` : ''}` +
+          `\nOK = încarcă, Cancel = ignoră`
+      );
+      if (ok) {
+        pendingRestore = candidate;
+        restoreMode = kind;
+        if (candidate.pagination && typeof candidate.pagination === 'object') {
+          if (candidate.pagination.mode) config.pagination.mode = candidate.pagination.mode;
+          if (candidate.pagination.param) config.pagination.param = candidate.pagination.param;
+          if (Number.isFinite(candidate.pagination.pageBase))
+            config.pagination.pageBase = candidate.pagination.pageBase;
+        }
+        if (Number.isFinite(candidate.scanStartPage)) config.startPage = candidate.scanStartPage;
+        else if (Number.isFinite(candidate.config?.startPage))
+          config.startPage = candidate.config.startPage;
+      }
     }
-    startPageInput = normalizeSpace(startPageInput);
-    const startPage = startPageInput === '' ? config.startPage : parseInt(startPageInput, 10);
-    if (!Number.isFinite(startPage) || startPage < 1) {
-      console.warn('Start page invalid. Scriptul a fost oprit.');
-      return;
+
+    if (pendingRestore == null) {
+      let startPageInput = prompt(
+        'De la ce pagină să încep scanarea?\n' +
+          '1 = de la început. Pentru resume, pune un număr mai mare.\n' +
+          'Enter = valoarea default.',
+        String(config.startPage)
+      );
+      if (startPageInput === null) {
+        console.warn('Nu a fost furnizat start page. Scriptul a fost oprit.');
+        return;
+      }
+      startPageInput = normalizeSpace(startPageInput);
+      const startPage = startPageInput === '' ? config.startPage : parseInt(startPageInput, 10);
+      if (!Number.isFinite(startPage) || startPage < 1) {
+        console.warn('Start page invalid. Scriptul a fost oprit.');
+        return;
+      }
+      config.startPage = startPage;
     }
-    config.startPage = startPage;
+
     const firstFetchedPageIndex = config.startPage;
+    let themePreference = loadThemePreference();
 
     // wipe the page and setup UI
     document.head.innerHTML = '';
     document.body.innerHTML = '';
+    themePreference = applyThemePreference(themePreference);
 
     const title = document.createElement('h2');
     title.style.display = 'block';
@@ -401,7 +523,6 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     style.innerHTML = `
         :root{
             font-family: Arial, sans-serif;
-            color-scheme: light dark;
             --bg: #ffffff;
             --text: #111827;
             --muted: #6b7280;
@@ -414,7 +535,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
             --link: #1d4ed8;
         }
         @media (prefers-color-scheme: dark){
-            :root{
+            :root:not([data-theme]){
                 --bg: #0b0f14;
                 --text: #e5e7eb;
                 --muted: #9ca3af;
@@ -427,6 +548,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
                 --link: #93c5fd;
             }
         }
+        :root{ color-scheme: light dark; }
+        :root[data-theme="light"]{ color-scheme: light; }
+        :root[data-theme="dark"]{ color-scheme: dark; }
+        :root[data-theme="dark"]{
+            --bg: #0b0f14;
+            --text: #e5e7eb;
+            --muted: #9ca3af;
+            --border: #243041;
+            --panel: #121826;
+            --btn-hover: #1b2a44;
+            --table-header-bg: #121826;
+            --table-row-alt: #0f1522;
+            --table-row-hover: #1b2a44;
+            --link: #93c5fd;
+        }
         body{margin:0;padding:0.9rem;background:var(--bg);color:var(--text);}
         a{color:var(--link);text-decoration:none;}
         a:hover{cursor:pointer;text-decoration:underline;}
@@ -436,6 +572,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         #controls label{display:flex;gap:0.4em;align-items:center;user-select:none;}
         #controls input[type="checkbox"]{accent-color:var(--link);}
         #controls input[type="number"]{width:8em;border:1px solid var(--border);border-radius:0.45em;padding:0.2em 0.35em;background:var(--bg);color:var(--text);}
+        #controls select{width:12em;border:1px solid var(--border);border-radius:0.45em;padding:0.25em 0.35em;background:var(--bg);color:var(--text);}
         #controls button{padding:0.35em 0.65em;border:1px solid var(--border);border-radius:0.45em;background:transparent;color:var(--text);}
         #controls button:hover{background:var(--btn-hover);}
         #controls button:disabled{opacity:0.55;cursor:not-allowed;}
@@ -491,15 +628,18 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     let pageSize = config.pageSize;
     let totalProblems = null;
     let totalPages = null;
-    const startedAt = Date.now();
+    let startedAt = Date.now();
 
     const stats = { solved: 0, tried: 0, unattempted: 0, total: 0, pages: 0 };
     let finished = false;
+    let scanEnd = null;
+    let restoringState = false;
     let stopRequested = false;
     let paused = false;
     let stopButton = null;
     let pauseButton = null;
     const activeRequests = new Set();
+    const activePageIndexes = new Set();
 
     const debugEnabled = Boolean(window.PBINFO_GET_UNSOLVED_DEBUG);
     const debugDumpLimit = Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_DEBUG_LIMIT))
@@ -617,6 +757,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     table.style.width = '75%';
     table.style.minWidth = '450px';
     table.style.maxWidth = '1050px';
+
+    function ensureResultsAttached() {
+      if (!table.isConnected) document.body.appendChild(table);
+      if (!listDiv.isConnected) document.body.appendChild(listDiv);
+    }
 
     function quickSort(arr, left, right, key) {
       let index;
@@ -809,6 +954,11 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       paused = !paused;
       if (pauseButton) pauseButton.textContent = paused ? 'Continuă' : 'Pauză';
       addLog(paused ? '<b>Scanare pusă pe pauză.</b>' : '<b>Scanare reluată.</b>');
+      if (paused) {
+        ensureResultsAttached();
+        renderResults();
+        saveScanState({ mode: 'full', reason: 'pause', silent: true });
+      }
       updateProgress(inFlight);
       if (!paused) {
         for (let i = 0; i < config.concurrency; i++) schedule(kick);
@@ -851,6 +1001,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       minInput.type = 'number';
       minInput.min = '0';
       minInput.placeholder = '-';
+      if (filterState.scoreMin != null && Number.isFinite(filterState.scoreMin)) {
+        minInput.value = String(filterState.scoreMin);
+      }
       minInput.addEventListener('input', () => {
         const v = Number(minInput.value);
         filterState.scoreMin = Number.isFinite(v) && minInput.value !== '' ? v : null;
@@ -865,6 +1018,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       maxInput.type = 'number';
       maxInput.min = '0';
       maxInput.placeholder = '-';
+      if (filterState.scoreMax != null && Number.isFinite(filterState.scoreMax)) {
+        maxInput.value = String(filterState.scoreMax);
+      }
       maxInput.addEventListener('input', () => {
         const v = Number(maxInput.value);
         filterState.scoreMax = Number.isFinite(v) && maxInput.value !== '' ? v : null;
@@ -884,6 +1040,32 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       unknownLabel.appendChild(unknownInput);
       unknownLabel.appendChild(document.createTextNode(' include scor necunoscut'));
       groupScore.appendChild(unknownLabel);
+
+      const groupAppearance = document.createElement('div');
+      groupAppearance.className = 'group';
+      groupAppearance.innerHTML = '<b>Aspect</b>';
+
+      const themeLabel = document.createElement('label');
+      themeLabel.textContent = 'Temă';
+      const themeSelect = document.createElement('select');
+      const themeOptions = [
+        { value: 'system', label: 'Sistem' },
+        { value: 'light', label: 'Light' },
+        { value: 'dark', label: 'Dark' },
+      ];
+      for (const o of themeOptions) {
+        const opt = document.createElement('option');
+        opt.value = o.value;
+        opt.textContent = o.label;
+        themeSelect.appendChild(opt);
+      }
+      themeSelect.value = themePreference;
+      themeSelect.addEventListener('change', () => {
+        themePreference = applyThemePreference(themeSelect.value);
+        themeSelect.value = themePreference;
+      });
+      themeLabel.appendChild(themeSelect);
+      groupAppearance.appendChild(themeLabel);
 
       const groupExport = document.createElement('div');
       groupExport.className = 'group';
@@ -979,6 +1161,91 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       });
       groupExport.appendChild(copyMarkdown);
 
+      const groupSession = document.createElement('div');
+      groupSession.className = 'group';
+      groupSession.innerHTML = '<b>Stare (local)</b>';
+
+      const saveStateBtn = document.createElement('button');
+      saveStateBtn.textContent = 'Salvează';
+      saveStateBtn.addEventListener('click', () => {
+        const res = saveScanState({ mode: 'full', reason: 'manual' });
+        if (!res.ok) {
+          addLog('<span style="color:#b30000;">Nu am putut salva starea.</span>');
+          return;
+        }
+        const note =
+          res.kind === 'full'
+            ? ' (salvat complet)'
+            : ' (salvat compact; posibilă limită de spațiu în localStorage)';
+        addLog(`Stare salvată${note}.`);
+        refreshSessionInfo();
+      });
+      groupSession.appendChild(saveStateBtn);
+
+      const loadStateBtn = document.createElement('button');
+      loadStateBtn.textContent = 'Încarcă';
+      loadStateBtn.addEventListener('click', () => {
+        if (!paused && !finished) {
+          addLog(
+            '<span style="color:#b35c00;">Pune scanarea pe pauză înainte să încarci o stare.</span>'
+          );
+          return;
+        }
+        if (inFlight > 0) {
+          addLog(
+            '<span style="color:#b35c00;">Așteaptă să se termine request-urile în lucru înainte să încarci o stare.</span>'
+          );
+          return;
+        }
+        const ok = confirm('Încarci starea salvată? Rezultatele curente vor fi înlocuite.');
+        if (!ok) return;
+        const loaded = loadSavedStateForLink();
+        if (!loaded) {
+          addLog('Nu există stare salvată pentru acest link.');
+          refreshSessionInfo();
+          return;
+        }
+        restoreFromSavedState(loaded.state, loaded.kind);
+        addLog('Stare încărcată.');
+        refreshSessionInfo();
+      });
+      groupSession.appendChild(loadStateBtn);
+
+      const clearStateBtn = document.createElement('button');
+      clearStateBtn.textContent = 'Șterge';
+      clearStateBtn.addEventListener('click', () => {
+        const ok = confirm('Ștergi starea salvată pentru acest link?');
+        if (!ok) return;
+        clearSavedStateForLink();
+        addLog('Stare ștearsă.');
+        refreshSessionInfo();
+      });
+      groupSession.appendChild(clearStateBtn);
+
+      const sessionInfo = document.createElement('div');
+      sessionInfo.className = 'muted';
+      groupSession.appendChild(sessionInfo);
+
+      function refreshSessionInfo() {
+        const existing = loadSavedStateForLink();
+        if (!existing) {
+          loadStateBtn.disabled = true;
+          clearStateBtn.disabled = true;
+          sessionInfo.textContent = 'Nicio stare salvată.';
+          return;
+        }
+        loadStateBtn.disabled = false;
+        clearStateBtn.disabled = false;
+        const savedAt = existing.state?.savedAt ? formatDateTime(existing.state.savedAt) : '-';
+        const level =
+          existing.kind === 'full'
+            ? 'complet'
+            : existing.state?.storageLevel === 'progress'
+              ? 'progres'
+              : 'compact';
+        sessionInfo.textContent = `Salvat (${level}) la ${savedAt}.`;
+      }
+
       const groupScan = document.createElement('div');
       groupScan.className = 'group';
       groupScan.innerHTML = '<b>Scan</b>';
@@ -998,7 +1265,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       scanNote.textContent = `resume: start page > 1 (curent ${config.startPage}) · maxPages=${config.maxPages}`;
       groupScan.appendChild(scanNote);
 
-      controlsDiv.replaceChildren(groupStatus, groupScore, groupExport, groupScan);
+      controlsDiv.replaceChildren(
+        groupStatus,
+        groupScore,
+        groupAppearance,
+        groupExport,
+        groupSession,
+        groupScan
+      );
+      refreshSessionInfo();
     }
 
     function formatDuration(ms) {
@@ -1179,12 +1454,17 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
 
     function finishScan({ complete, reason }) {
       if (finished) return;
+      scanEnd = {
+        finished: true,
+        complete: Boolean(complete),
+        reason: reason ? String(reason) : null,
+        endedAt: Date.now(),
+      };
       finished = true;
       if (pauseButton) pauseButton.disabled = true;
       if (stopButton) stopButton.disabled = true;
 
-      document.body.appendChild(table);
-      document.body.appendChild(listDiv);
+      ensureResultsAttached();
       renderResults();
 
       const summary = `Rezumat: ${stats.solved} rezolvate, ${stats.tried} încercate, ${stats.unattempted} neîncercate (total ${stats.total}, pagini ${stats.pages}).`;
@@ -1195,6 +1475,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         addLog(
           `<u>Am terminat de extras problemele.</u> Sunt ${unsolvedCount} probleme nerezolvate. Tabelul și lista au fost adăugate mai jos.`
         );
+        saveScanState({ mode: 'full', reason: 'complete', silent: true });
         return;
       }
 
@@ -1202,6 +1483,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       addLog(
         `<span style="color:#b30000;"><u>Scanarea s-a oprit înainte de final.</u></span>${reasonText}`
       );
+      saveScanState({ mode: 'full', reason: 'stopped', silent: true });
     }
 
     // Fetch pages (optional concurrency)
@@ -1211,6 +1493,358 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
     let nextSequentialPage = null;
     let queueInitialized = false;
     let inFlight = 0;
+
+    const autosaveConfig = {
+      enabled: window.PBINFO_GET_UNSOLVED_AUTOSAVE !== false,
+      everyPages: Math.max(
+        1,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_AUTOSAVE_PAGES))
+          ? Number(window.PBINFO_GET_UNSOLVED_AUTOSAVE_PAGES)
+          : 50
+      ),
+      everyMs: Math.max(
+        5000,
+        Number.isFinite(Number(window.PBINFO_GET_UNSOLVED_AUTOSAVE_MS))
+          ? Number(window.PBINFO_GET_UNSOLVED_AUTOSAVE_MS)
+          : 120000
+      ),
+    };
+    let lastAutosaveAt = 0;
+    let lastAutosavePages = 0;
+    let autosaveDisabled = false;
+
+    function loadSavedStateForLink() {
+      const read = (key) => {
+        try {
+          return safeJsonParse(localStorage.getItem(key));
+        } catch {
+          return null;
+        }
+      };
+      const full = read(stateKeys.full);
+      if (full && full.pageLink === pageLink) return { kind: 'full', state: full };
+      const minimal = read(stateKeys.minimal);
+      if (minimal && minimal.pageLink === pageLink) return { kind: 'minimal', state: minimal };
+      return null;
+    }
+
+    function clearSavedStateForLink() {
+      try {
+        localStorage.removeItem(stateKeys.full);
+      } catch {}
+      try {
+        localStorage.removeItem(stateKeys.minimal);
+      } catch {}
+    }
+
+    function serializeFilters() {
+      return {
+        statuses: Array.from(filterState.statuses),
+        includeUnknownScore: Boolean(filterState.includeUnknownScore),
+        scoreMin: Number.isFinite(filterState.scoreMin) ? filterState.scoreMin : null,
+        scoreMax: Number.isFinite(filterState.scoreMax) ? filterState.scoreMax : null,
+      };
+    }
+
+    function serializeSorted() {
+      return { ...sorted };
+    }
+
+    function serializeProblem(p, level) {
+      const base = {
+        id: p?.id,
+        name: p?.name,
+        link: p?.link,
+        difficulty: p?.difficulty,
+        status: p?.status,
+        userScore: Number.isFinite(p?.userScore) ? p.userScore : null,
+        maxScore: Number.isFinite(p?.maxScore) ? p.maxScore : null,
+      };
+      if (level === 'minimal') return base;
+      return {
+        ...base,
+        postedBy_link: p?.postedBy_link,
+        postedBy_name: p?.postedBy_name,
+        postedBy_img: p?.postedBy_img,
+        author: p?.author,
+        source: p?.source,
+      };
+    }
+
+    function computeResumeFromStateSnapshot(snapshot) {
+      const candidates = [];
+      const q = Array.isArray(snapshot?.pageQueue) ? snapshot.pageQueue : [];
+      if (q.length > 0 && Number.isFinite(q[0])) candidates.push(q[0]);
+      const d = Array.isArray(snapshot?.deferred) ? snapshot.deferred : [];
+      for (const entry of d) {
+        const pageIndex = Array.isArray(entry) ? entry[0] : entry?.pageIndex;
+        if (Number.isFinite(pageIndex)) candidates.push(pageIndex);
+      }
+      const f = Array.isArray(snapshot?.inFlightPages) ? snapshot.inFlightPages : [];
+      for (const pageIndex of f) if (Number.isFinite(pageIndex)) candidates.push(pageIndex);
+      if (Number.isFinite(snapshot?.nextSequentialPage))
+        candidates.push(snapshot.nextSequentialPage);
+      const min = candidates.length > 0 ? Math.min(...candidates) : null;
+      return Number.isFinite(min) ? min : null;
+    }
+
+    function buildStateSnapshot(level, reason) {
+      const now = Date.now();
+      const snapshot = {
+        version: STATE_STORAGE_VERSION,
+        storageLevel: level,
+        savedAt: now,
+        pageLink,
+        pagination: { ...config.pagination },
+        scanStartPage: config.startPage,
+        pageSize: Number.isFinite(pageSize) ? pageSize : null,
+        totalProblems: Number.isFinite(totalProblems) ? totalProblems : null,
+        totalPages: Number.isFinite(totalPages) ? totalPages : null,
+        elapsedMs: now - startedAt,
+        stats: { ...stats },
+        filters: serializeFilters(),
+        sorted: serializeSorted(),
+        queueInitialized: Boolean(queueInitialized),
+        pageQueue: Array.from(pageQueue),
+        deferred: Array.from(deferredPageRequests.entries()),
+        nextSequentialPage: Number.isFinite(nextSequentialPage) ? nextSequentialPage : null,
+        inFlightPages: Array.from(activePageIndexes),
+        paused: Boolean(paused),
+        stopRequested: Boolean(stopRequested),
+        end: scanEnd,
+        reason: reason ? String(reason) : null,
+      };
+
+      snapshot.resumeFromPage = computeResumeFromStateSnapshot(snapshot);
+
+      if (level === 'progress') {
+        snapshot.seenProblemIds = Array.from(seenProblemIds);
+        return snapshot;
+      }
+
+      snapshot.problems = allProblems.map((p) => serializeProblem(p, level));
+      snapshot.seenProblemIds = Array.from(seenProblemIds);
+      return snapshot;
+    }
+
+    function saveScanState({ mode, reason, silent } = {}) {
+      const desired = mode === 'minimal' || mode === 'progress' ? mode : 'full';
+      const write = (key, value) => {
+        localStorage.setItem(key, JSON.stringify(value));
+      };
+
+      try {
+        if (desired === 'full') {
+          const snap = buildStateSnapshot('full', reason);
+          write(stateKeys.full, snap);
+          try {
+            localStorage.removeItem(stateKeys.minimal);
+          } catch {}
+          return { ok: true, kind: 'full' };
+        }
+      } catch (err) {
+        if (!silent) console.warn('Failed to save full state:', err);
+      }
+
+      try {
+        const snap = buildStateSnapshot('minimal', reason);
+        write(stateKeys.minimal, snap);
+        return { ok: true, kind: 'minimal' };
+      } catch (err) {
+        if (!silent) console.warn('Failed to save minimal state:', err);
+      }
+
+      try {
+        const snap = buildStateSnapshot('progress', reason);
+        write(stateKeys.minimal, snap);
+        return { ok: true, kind: 'minimal' };
+      } catch (err) {
+        if (!silent) console.warn('Failed to save progress state:', err);
+        return { ok: false, kind: null };
+      }
+    }
+
+    function restoreFromSavedState(state, kind) {
+      if (!state || state.pageLink !== pageLink) return false;
+      restoringState = true;
+      try {
+        for (const xhr of activeRequests) {
+          try {
+            xhr.abort();
+          } catch {}
+        }
+        activeRequests.clear();
+        activePageIndexes.clear();
+        inFlight = 0;
+
+        stopRequested = Boolean(state.stopRequested);
+        paused = Boolean(state.paused);
+        scanEnd = state.end && typeof state.end === 'object' ? state.end : null;
+
+        if (state.pagination && typeof state.pagination === 'object') {
+          if (state.pagination.mode) config.pagination.mode = state.pagination.mode;
+          if (state.pagination.param) config.pagination.param = state.pagination.param;
+          if (Number.isFinite(state.pagination.pageBase))
+            config.pagination.pageBase = state.pagination.pageBase;
+        }
+
+        if (Number.isFinite(state.scanStartPage)) config.startPage = state.scanStartPage;
+
+        const elapsed = Number.isFinite(state.elapsedMs) ? state.elapsedMs : null;
+        if (elapsed != null && elapsed >= 0) startedAt = Date.now() - elapsed;
+
+        pageSize = Number.isFinite(state.pageSize) ? state.pageSize : pageSize;
+        totalProblems = Number.isFinite(state.totalProblems) ? state.totalProblems : totalProblems;
+        totalPages = Number.isFinite(state.totalPages) ? state.totalPages : totalPages;
+
+        if (state.stats && typeof state.stats === 'object') {
+          stats.solved = Number.isFinite(state.stats.solved) ? state.stats.solved : 0;
+          stats.tried = Number.isFinite(state.stats.tried) ? state.stats.tried : 0;
+          stats.unattempted = Number.isFinite(state.stats.unattempted)
+            ? state.stats.unattempted
+            : 0;
+          stats.total = Number.isFinite(state.stats.total) ? state.stats.total : 0;
+          stats.pages = Number.isFinite(state.stats.pages) ? state.stats.pages : 0;
+        }
+
+        allProblems.length = 0;
+        seenProblemIds.clear();
+
+        const problems = Array.isArray(state.problems) ? state.problems : [];
+        for (const p of problems) {
+          const id = Number.isFinite(p?.id) ? p.id : NaN;
+          if (!Number.isFinite(id)) continue;
+          const userScore = Number.isFinite(p?.userScore) ? p.userScore : null;
+          const maxScore = Number.isFinite(p?.maxScore) ? p.maxScore : 100;
+          const status =
+            p?.status === 'solved' || p?.status === 'tried' || p?.status === 'unattempted'
+              ? p.status
+              : classifyProblemStatus({ userScore, maxScore });
+          const scoreKnown = userScore != null && Number.isFinite(userScore);
+          allProblems.push({
+            cnt: allProblems.length + 1,
+            id,
+            name: typeof p?.name === 'string' ? p.name : '',
+            link: typeof p?.link === 'string' ? p.link : '',
+            difficulty: Number.isFinite(p?.difficulty) ? p.difficulty : 3,
+            score: scoreKnown ? userScore : -1,
+            scoreKnown,
+            userScore,
+            maxScore,
+            status,
+            postedBy_link: typeof p?.postedBy_link === 'string' ? p.postedBy_link : '',
+            postedBy_name: typeof p?.postedBy_name === 'string' ? p.postedBy_name : '',
+            postedBy_img: typeof p?.postedBy_img === 'string' ? p.postedBy_img : '',
+            author: typeof p?.author === 'string' ? p.author : '',
+            source: typeof p?.source === 'string' ? p.source : '',
+          });
+          seenProblemIds.add(id);
+        }
+
+        if (Array.isArray(state.seenProblemIds) && state.seenProblemIds.length > 0) {
+          for (const n of state.seenProblemIds) {
+            const id = parseInt(n, 10);
+            if (Number.isFinite(id)) seenProblemIds.add(id);
+          }
+        }
+
+        if (state.filters && typeof state.filters === 'object') {
+          const statuses = new Set(
+            Array.isArray(state.filters.statuses) ? state.filters.statuses : []
+          );
+          filterState.statuses.clear();
+          for (const s of ['solved', 'tried', 'unattempted']) {
+            if (statuses.has(s)) filterState.statuses.add(s);
+          }
+          if (filterState.statuses.size === 0) {
+            filterState.statuses.add('tried');
+            filterState.statuses.add('unattempted');
+          }
+          filterState.includeUnknownScore = Boolean(state.filters.includeUnknownScore);
+          filterState.scoreMin = Number.isFinite(state.filters.scoreMin)
+            ? state.filters.scoreMin
+            : null;
+          filterState.scoreMax = Number.isFinite(state.filters.scoreMax)
+            ? state.filters.scoreMax
+            : null;
+        }
+
+        if (state.sorted && typeof state.sorted === 'object') {
+          for (const k of Object.keys(sorted)) {
+            sorted[k] = Number.isFinite(state.sorted[k]) ? state.sorted[k] : 0;
+          }
+        }
+
+        pageQueue.length = 0;
+        deferredPageRequests.clear();
+        queueInitialized = Boolean(state.queueInitialized);
+        if (Array.isArray(state.pageQueue)) {
+          for (const n of state.pageQueue) if (Number.isFinite(n)) pageQueue.push(n);
+        }
+        if (Array.isArray(state.deferred)) {
+          for (const [pageIndex, retryCount] of state.deferred) {
+            if (Number.isFinite(pageIndex) && Number.isFinite(retryCount)) {
+              deferredPageRequests.set(pageIndex, retryCount);
+            }
+          }
+        }
+        nextSequentialPage = Number.isFinite(state.nextSequentialPage)
+          ? state.nextSequentialPage
+          : null;
+        if (nextSequentialPage == null && Number.isFinite(state.resumeFromPage)) {
+          nextSequentialPage = state.resumeFromPage;
+        }
+
+        if (Array.isArray(state.inFlightPages)) {
+          for (const pageIndex of state.inFlightPages) deferPage(pageIndex, 0);
+        }
+
+        finished = Boolean(scanEnd?.finished);
+        setupControls();
+
+        if (pauseButton) pauseButton.textContent = paused ? 'Continuă' : 'Pauză';
+        if (pauseButton) pauseButton.disabled = finished;
+        if (stopButton) stopButton.disabled = finished;
+
+        if (allProblems.length > 0) ensureResultsAttached();
+        renderResults();
+        updateProgress(inFlight);
+
+        if (kind === 'minimal' && state.storageLevel === 'progress') {
+          addLog(
+            '<span style="color:#b35c00;"><b>Notă:</b> stare salvată doar ca progres; lista completă nu este disponibilă.</span>'
+          );
+        } else if (kind === 'minimal') {
+          addLog(
+            '<span style="color:#b35c00;"><b>Notă:</b> stare salvată compact; unele metadate (autor/sursă) pot lipsi.</span>'
+          );
+        }
+
+        return true;
+      } finally {
+        restoringState = false;
+      }
+    }
+
+    function maybeAutoSave(reason) {
+      if (!autosaveConfig.enabled || autosaveDisabled) return;
+      const now = Date.now();
+      if (
+        stats.pages - lastAutosavePages < autosaveConfig.everyPages &&
+        now - lastAutosaveAt < autosaveConfig.everyMs
+      )
+        return;
+      const res = saveScanState({ mode: 'minimal', reason: reason || 'autosave', silent: true });
+      if (!res.ok) {
+        autosaveDisabled = true;
+        addLog(
+          '<span style="color:#b35c00;"><b>Autosave:</b> dezactivat (nu am putut salva în localStorage).</span>'
+        );
+        return;
+      }
+      lastAutosaveAt = now;
+      lastAutosavePages = stats.pages;
+    }
 
     function schedule(fn) {
       if (config.delayMs > 0) setTimeout(fn, config.delayMs);
@@ -1323,11 +1957,13 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       updateProgress(inFlight);
       const xhr = new XMLHttpRequest();
       activeRequests.add(xhr);
+      activePageIndexes.add(pageIndex);
       let finalized = false;
       const finalize = () => {
         if (finalized) return;
         finalized = true;
         activeRequests.delete(xhr);
+        activePageIndexes.delete(pageIndex);
         inFlight = Math.max(0, inFlight - 1);
         updateProgress(inFlight);
       };
@@ -1344,6 +1980,10 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       xhr.timeout = config.timeoutMs;
       xhr.onload = () => {
         const responseText = xhr.responseText || xhr.response || '';
+        if (stopRequested || finished || restoringState) {
+          finalize();
+          return;
+        }
         if (xhr.status !== 200) {
           if (retryCount < maxRetriesPerPage) {
             const delay = 1000 * (retryCount + 1);
@@ -1447,11 +2087,21 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         let pageUnattempted = 0;
         let totalCount = 0;
         let parseFailCount = 0;
+        let idFailCount = 0;
 
         for (let card of cards) {
           const codeEl = card.querySelector('code');
           if (!codeEl) continue;
-          const id = parseInt(codeEl.innerText.trim().slice(1));
+          const idText = normalizeSpace(codeEl.textContent);
+          const idMatch = /(\d+)/.exec(idText);
+          const id = idMatch ? parseInt(idMatch[1], 10) : NaN;
+          if (!Number.isFinite(id)) {
+            idFailCount++;
+            if (debugEnabled && debugDumped < debugDumpLimit && !debugIds) {
+              debugDumpCard(card, { id: null, name: null, link: null, scoreInfo: null });
+            }
+            continue;
+          }
           if (seenProblemIds.has(id)) continue;
           seenProblemIds.add(id);
           totalCount++;
@@ -1495,7 +2145,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           // author
           let author = '';
           const authorSpan = card.querySelector('span[title="Autor"]');
-          if (authorSpan) author = authorSpan.innerText.replace(/^[\s\S]*?\s/, '').trim();
+          if (authorSpan) author = normalizeSpace(authorSpan.textContent);
           // source
           let source = '';
           const srcBlock = card.querySelector('blockquote[title="Sursa problemei"]');
@@ -1548,8 +2198,9 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
         const scoreUnavailable = pageUnattempted === totalCount;
         const scoreWarning = scoreUnavailable ? ' (punctaj indisponibil pentru toate)' : '';
         const parseFailSuffix = parseFailCount > 0 ? ` · parseFail=${parseFailCount}` : '';
+        const idFailSuffix = idFailCount > 0 ? ` · idFail=${idFailCount}` : '';
         addLog(
-          `Pagina ${pageIndex}: rezolvate ${pageSolved}, încercate ${pageTried}, neîncercate ${pageUnattempted} (total ${totalCount})${scoreWarning}${parseFailSuffix}.`
+          `Pagina ${pageIndex}: rezolvate ${pageSolved}, încercate ${pageTried}, neîncercate ${pageUnattempted} (total ${totalCount})${scoreWarning}${parseFailSuffix}${idFailSuffix}.`
         );
         if (pageIndex === firstFetchedPageIndex && totalCount > 0 && scoreUnavailable) {
           addLog(
@@ -1557,6 +2208,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
           );
         }
 
+        maybeAutoSave('page');
         finalize();
         if (queueInitialized) {
           schedule(kick);
@@ -1567,11 +2219,12 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       };
       xhr.onabort = () => {
         finalize();
-        if (stopRequested || finished) return;
+        if (stopRequested || finished || restoringState) return;
         finishScan({ complete: false, reason: `Request abort la pagina ${pageIndex}` });
       };
       xhr.ontimeout = () => {
         finalize();
+        if (stopRequested || finished || restoringState) return;
         if (retryCount < maxRetriesPerPage) {
           const delay = 1000 * (retryCount + 1);
           addLog(`Timeout la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
@@ -1582,7 +2235,7 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       };
       xhr.onerror = () => {
         finalize();
-        if (stopRequested || finished) return;
+        if (stopRequested || finished || restoringState) return;
         if (retryCount < maxRetriesPerPage) {
           const delay = 1000 * (retryCount + 1);
           addLog(`Eroare de rețea la pagina ${pageIndex}. Reîncerc în ${delay / 1000}s...`);
@@ -1594,6 +2247,15 @@ if (typeof window === 'undefined' || typeof document === 'undefined') {
       xhr.send();
     }
 
-    fetchPage(config.startPage, 0);
+    if (pendingRestore) {
+      restoreFromSavedState(pendingRestore, restoreMode);
+      pendingRestore = null;
+      restoreMode = null;
+      if (!finished && !stopRequested && !paused) {
+        for (let i = 0; i < config.concurrency; i++) schedule(kick);
+      }
+    } else {
+      fetchPage(config.startPage, 0);
+    }
   })();
 }

--- a/scripts/build-bookmarklet.cjs
+++ b/scripts/build-bookmarklet.cjs
@@ -1,0 +1,40 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { minify } = require('terser');
+
+async function main() {
+  const rootDir = path.resolve(__dirname, '..');
+  const srcPath = path.join(rootDir, 'pbinfo-get-unsolved-enhanced.js');
+  const distDir = path.join(rootDir, 'dist');
+
+  const source = fs.readFileSync(srcPath, 'utf8');
+
+  const wrapped = `(()=>{\n${source}\n})();`;
+  const result = await minify(wrapped, {
+    compress: true,
+    mangle: true,
+  });
+
+  if (!result || typeof result.code !== 'string' || result.code.length === 0) {
+    throw new Error('Terser did not return minified code.');
+  }
+
+  fs.mkdirSync(distDir, { recursive: true });
+
+  const minPath = path.join(distDir, 'pbinfo-get-unsolved.min.js');
+  fs.writeFileSync(minPath, result.code, 'utf8');
+
+  const bookmarklet = `javascript:${encodeURIComponent(result.code)}`;
+  const bookmarkletPath = path.join(distDir, 'pbinfo-get-unsolved.bookmarklet.txt');
+  fs.writeFileSync(bookmarkletPath, bookmarklet, 'utf8');
+
+  console.log(`Wrote ${path.relative(rootDir, minPath)}`);
+  console.log(`Wrote ${path.relative(rootDir, bookmarkletPath)}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});
+

--- a/scripts/build-bookmarklet.cjs
+++ b/scripts/build-bookmarklet.cjs
@@ -37,4 +37,3 @@ main().catch((err) => {
   console.error(err);
   process.exitCode = 1;
 });
-

--- a/tests/fixtures/card-score-ambiguous-100.html
+++ b/tests/fixtures/card-score-ambiguous-100.html
@@ -1,0 +1,13 @@
+<div class="card mb-3">
+  <div class="card-header bg-info-subtle">
+    <div class="d-flex justify-content-between align-items-center">
+      <h5 class="card-title my-0">
+        <a href="/probleme/4936/lazig" class="text-decoration-none me-3">LaziG</a>
+      </h5>
+      <div><code>#4936</code></div>
+    </div>
+  </div>
+  <div class="card-body">
+    <span class="badge bg-secondary me-2" title="Punctaj">100p</span>
+  </div>
+</div>

--- a/tests/fixtures/card-score-data-bs-title.html
+++ b/tests/fixtures/card-score-data-bs-title.html
@@ -1,0 +1,14 @@
+<div class="card mb-3">
+  <div class="card-header bg-info-subtle">
+    <div class="d-flex justify-content-between align-items-center">
+      <h5 class="card-title my-0">
+        <a href="/probleme/4929/fortificari" class="text-decoration-none me-3">Fortificari</a>
+      </h5>
+      <div><code>#4929</code></div>
+    </div>
+  </div>
+  <div class="card-body">
+    <span class="badge bg-secondary me-2" data-bs-title="Punctaj maxim">100p</span>
+    <span class="badge bg-secondary me-2" data-bs-title="Punctaj obținut">65p</span>
+  </div>
+</div>

--- a/tests/fixtures/card-score-footer-user-max.html
+++ b/tests/fixtures/card-score-footer-user-max.html
@@ -1,0 +1,25 @@
+<div class="card mb-3">
+  <div class="card-header bg-info-subtle">
+    <div class="d-flex justify-content-between align-items-center">
+      <h5 class="card-title my-0">
+        <a href="/probleme/4906/numere-p10" class="text-decoration-none me-3">numere_p10</a>
+      </h5>
+      <div><code>#4906</code></div>
+    </div>
+  </div>
+  <div class="card-body">
+    <div class="border rounded p-2 bg-body-secondary">
+      <div class="d-flex align-items-center mb-2 flex-wrap">
+        <span class="badge bg-success me-2" title="Dificultate">ușoară</span>
+      </div>
+    </div>
+  </div>
+  <div class="card-footer text-end">
+    <a href="/probleme/4906/numere-p10" class="btn btn-primary">
+      Rezolvă
+      <span style="background-color: #bdf7c5" title="Punctajul tău maxim" class="badge text-dark"
+        >100</span
+      >
+    </a>
+  </div>
+</div>

--- a/tests/fixtures/card-score-ratio.html
+++ b/tests/fixtures/card-score-ratio.html
@@ -1,0 +1,13 @@
+<div class="card mb-3">
+  <div class="card-header bg-info-subtle">
+    <div class="d-flex justify-content-between align-items-center">
+      <h5 class="card-title my-0">
+        <a href="/probleme/4930/constelatii" class="text-decoration-none me-3">Constelatii</a>
+      </h5>
+      <div><code>#4930</code></div>
+    </div>
+  </div>
+  <div class="card-body">
+    <span class="badge bg-secondary me-2" title="Punctaj obținut">30/100</span>
+  </div>
+</div>

--- a/tests/fixtures/card-score-title.html
+++ b/tests/fixtures/card-score-title.html
@@ -1,0 +1,14 @@
+<div class="card mb-3">
+  <div class="card-header bg-info-subtle">
+    <div class="d-flex justify-content-between align-items-center">
+      <h5 class="card-title my-0">
+        <a href="/probleme/4926/pandemica" class="text-decoration-none me-3">Pandemica</a>
+      </h5>
+      <div><code>#4926</code></div>
+    </div>
+  </div>
+  <div class="card-body">
+    <span class="badge bg-secondary me-2" title="Punctaj maxim">100p</span>
+    <span class="badge bg-secondary me-2" title="Punctaj obținut">0p</span>
+  </div>
+</div>

--- a/tests/fixtures/list-header-total.html
+++ b/tests/fixtures/list-header-total.html
@@ -1,0 +1,3 @@
+<h1 class="text-primary">
+  Lista de probleme <span class="badge bg-primary numar_probleme">187</span>
+</h1>

--- a/tests/fixtures/problem-page-no-score.html
+++ b/tests/fixtures/problem-page-no-score.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="ro">
+  <head>
+    <title>Pagina nu există. - pbinfo.ro</title>
+  </head>
+  <body>
+    <h1>Pagina nu există.</h1>
+  </body>
+</html>

--- a/tests/fixtures/problem-page-score-100.html
+++ b/tests/fixtures/problem-page-score-100.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="ro">
+  <head>
+    <title>sum - pbinfo.ro</title>
+    <link rel="canonical" href="https://www.pbinfo.ro/probleme/1/sum" />
+    <meta property="og:title" content="sum - pbinfo.ro" />
+  </head>
+  <body>
+    <h1><span class="badge">#1</span> sum</h1>
+    <div class="table-responsive">
+      <table class="table table-borderless">
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.pbinfo.ro/utilizator/123/candale">
+                <img src="https://www.gravatar.com/avatar/abc?s=64" alt="" />
+                Silviu Candale
+              </a>
+            </td>
+            <td class="center">9</td>
+            <td>sum.in / sum.out</td>
+            <td>1 secunde</td>
+            <td>64 MB / 8 MB</td>
+            <td class="center">-</td>
+            <td>Silviu Candale</td>
+            <td class="center">ușoară</td>
+            <td id="scor_utilizator_problema" class="center">
+              <a
+                href="/detalii-evaluare/14439679"
+                class="text-decoration-none badge bg-secondary"
+                title="Cel mai mare scor la aceasta problema: 100"
+                >100</a
+              >
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/problem-page-score-42.html
+++ b/tests/fixtures/problem-page-score-42.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="ro">
+  <head>
+    <title>foo - pbinfo.ro</title>
+    <link rel="canonical" href="https://www.pbinfo.ro/probleme/2/foo" />
+  </head>
+  <body>
+    <h1><span class="badge">#2</span> foo</h1>
+    <div class="table-responsive">
+      <table class="table table-borderless">
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://www.pbinfo.ro/utilizator/999/test">Test User</a>
+            </td>
+            <td class="center">11</td>
+            <td>foo.in / foo.out</td>
+            <td>1 secunde</td>
+            <td>64 MB / 8 MB</td>
+            <td class="center">-</td>
+            <td>Test Author</td>
+            <td class="center">medie</td>
+            <td id="scor_utilizator_problema" class="center">
+              <a
+                href="/detalii-evaluare/1"
+                class="text-decoration-none badge bg-secondary"
+                title="Cel mai mare scor la aceasta problema: 42"
+                >42</a
+              >
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>
+</html>

--- a/tests/fuzz-score-parsing.test.js
+++ b/tests/fuzz-score-parsing.test.js
@@ -1,0 +1,84 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseScoreText, selectScoreFromCandidates } = require('../pbinfo-get-unsolved-enhanced.js');
+
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randInt(rng, min, max) {
+  return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+function randChoice(rng, items) {
+  return items[randInt(rng, 0, items.length - 1)];
+}
+
+function randomNoise(rng, maxLen = 16) {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ -_:/[](){}!?,.;';
+  const len = randInt(rng, 0, maxLen);
+  let out = '';
+  for (let i = 0; i < len; i++) out += chars[randInt(rng, 0, chars.length - 1)];
+  return out;
+}
+
+function randomScoreString(rng) {
+  const kind = randChoice(rng, ['ratio', 'pct', 'points', 'bare', 'junk']);
+  const a = randInt(rng, 0, 120);
+  const b = randInt(rng, 1, 120);
+  const prefix = randomNoise(rng);
+  const suffix = randomNoise(rng);
+  if (kind === 'ratio') return `${prefix}${a}/${b}${suffix}`;
+  if (kind === 'pct') return `${prefix}${a}%${suffix}`;
+  if (kind === 'points') return `${prefix}${a}p${suffix}`;
+  if (kind === 'bare') return `${prefix}${a}${suffix}`;
+  return `${prefix}${randomNoise(rng, 32)}${suffix}`;
+}
+
+test('fuzz: parseScoreText never throws and returns sane ranges', () => {
+  const rng = mulberry32(0xdecafbad);
+  for (let i = 0; i < 2000; i++) {
+    const s = randomScoreString(rng);
+    const parsed = parseScoreText(s);
+    if (parsed == null) continue;
+    assert.ok(Number.isFinite(parsed.value));
+    assert.ok(parsed.value >= 0 && parsed.value <= 999);
+    if (parsed.max != null) {
+      assert.ok(Number.isFinite(parsed.max));
+      assert.ok(parsed.max >= 0 && parsed.max <= 999);
+    }
+  }
+});
+
+test('fuzz: selectScoreFromCandidates never throws', () => {
+  const rng = mulberry32(0x12345678);
+  for (let i = 0; i < 1000; i++) {
+    const count = randInt(rng, 0, 6);
+    const candidates = [];
+    for (let j = 0; j < count; j++) {
+      const text = randomScoreString(rng);
+      const parsed = parseScoreText(text);
+      candidates.push({
+        tooltip: randChoice(rng, ['', 'Punctaj obținut', 'Punctaj maxim', 'Punctajul tău maxim']),
+        text,
+        value: parsed?.value,
+        max: parsed?.max,
+        hasRatio: Boolean(parsed?.hasRatio),
+        isLink: rng() > 0.5,
+      });
+    }
+    const res = selectScoreFromCandidates(candidates);
+    assert.ok(Object.prototype.hasOwnProperty.call(res, 'userScore'));
+    assert.ok(Object.prototype.hasOwnProperty.call(res, 'maxScore'));
+    if (res.userScore != null) assert.ok(Number.isFinite(res.userScore));
+    if (res.maxScore != null) assert.ok(Number.isFinite(res.maxScore));
+  }
+});

--- a/tests/html-fixtures.test.js
+++ b/tests/html-fixtures.test.js
@@ -26,28 +26,40 @@ function parseCard(html) {
 test('fixture: title tooltip score -> tried', () => {
   const card = parseCard(loadFixture('card-score-title.html'));
   const info = extractScoreInfoFromCard(card);
-  assert.deepEqual({ userScore: info.userScore, maxScore: info.maxScore }, { userScore: 0, maxScore: 100 });
+  assert.deepEqual(
+    { userScore: info.userScore, maxScore: info.maxScore },
+    { userScore: 0, maxScore: 100 }
+  );
   assert.equal(classifyProblemStatus(info), 'tried');
 });
 
 test('fixture: data-bs-title tooltip score -> tried', () => {
   const card = parseCard(loadFixture('card-score-data-bs-title.html'));
   const info = extractScoreInfoFromCard(card);
-  assert.deepEqual({ userScore: info.userScore, maxScore: info.maxScore }, { userScore: 65, maxScore: 100 });
+  assert.deepEqual(
+    { userScore: info.userScore, maxScore: info.maxScore },
+    { userScore: 65, maxScore: 100 }
+  );
   assert.equal(classifyProblemStatus(info), 'tried');
 });
 
 test('fixture: ratio score -> tried', () => {
   const card = parseCard(loadFixture('card-score-ratio.html'));
   const info = extractScoreInfoFromCard(card);
-  assert.deepEqual({ userScore: info.userScore, maxScore: info.maxScore }, { userScore: 30, maxScore: 100 });
+  assert.deepEqual(
+    { userScore: info.userScore, maxScore: info.maxScore },
+    { userScore: 30, maxScore: 100 }
+  );
   assert.equal(classifyProblemStatus(info), 'tried');
 });
 
 test('fixture: ambiguous 100p -> unattempted', () => {
   const card = parseCard(loadFixture('card-score-ambiguous-100.html'));
   const info = extractScoreInfoFromCard(card);
-  assert.deepEqual({ userScore: info.userScore, maxScore: info.maxScore }, { userScore: null, maxScore: 100 });
+  assert.deepEqual(
+    { userScore: info.userScore, maxScore: info.maxScore },
+    { userScore: null, maxScore: 100 }
+  );
   assert.equal(classifyProblemStatus(info), 'unattempted');
 });
 

--- a/tests/html-fixtures.test.js
+++ b/tests/html-fixtures.test.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { parseHTML } = require('linkedom');
+
+const {
+  extractScoreInfoFromCard,
+  classifyProblemStatus,
+  parseTotalProblems,
+} = require('../pbinfo-get-unsolved-enhanced.js');
+
+function loadFixture(name) {
+  const p = path.join(__dirname, 'fixtures', name);
+  return fs.readFileSync(p, 'utf8');
+}
+
+function parseCard(html) {
+  const { document } = parseHTML(html);
+  const card = document.querySelector('div.card.mb-3');
+  assert.ok(card, 'fixture should contain a card');
+  return card;
+}
+
+test('fixture: title tooltip score -> tried', () => {
+  const card = parseCard(loadFixture('card-score-title.html'));
+  const info = extractScoreInfoFromCard(card);
+  assert.deepEqual({ userScore: info.userScore, maxScore: info.maxScore }, { userScore: 0, maxScore: 100 });
+  assert.equal(classifyProblemStatus(info), 'tried');
+});
+
+test('fixture: data-bs-title tooltip score -> tried', () => {
+  const card = parseCard(loadFixture('card-score-data-bs-title.html'));
+  const info = extractScoreInfoFromCard(card);
+  assert.deepEqual({ userScore: info.userScore, maxScore: info.maxScore }, { userScore: 65, maxScore: 100 });
+  assert.equal(classifyProblemStatus(info), 'tried');
+});
+
+test('fixture: ratio score -> tried', () => {
+  const card = parseCard(loadFixture('card-score-ratio.html'));
+  const info = extractScoreInfoFromCard(card);
+  assert.deepEqual({ userScore: info.userScore, maxScore: info.maxScore }, { userScore: 30, maxScore: 100 });
+  assert.equal(classifyProblemStatus(info), 'tried');
+});
+
+test('fixture: ambiguous 100p -> unattempted', () => {
+  const card = parseCard(loadFixture('card-score-ambiguous-100.html'));
+  const info = extractScoreInfoFromCard(card);
+  assert.deepEqual({ userScore: info.userScore, maxScore: info.maxScore }, { userScore: null, maxScore: 100 });
+  assert.equal(classifyProblemStatus(info), 'unattempted');
+});
+
+test('fixture: parseTotalProblems', () => {
+  const html = loadFixture('list-header-total.html');
+  assert.equal(parseTotalProblems(html), 187);
+});

--- a/tests/html-fixtures.test.js
+++ b/tests/html-fixtures.test.js
@@ -7,6 +7,8 @@ const { parseHTML } = require('linkedom');
 
 const {
   extractScoreInfoFromCard,
+  extractScoreInfoFromProblemPage,
+  extractProblemMetaFromProblemPage,
   classifyProblemStatus,
   parseTotalProblems,
 } = require('../pbinfo-get-unsolved-enhanced.js');
@@ -21,6 +23,11 @@ function parseCard(html) {
   const card = document.querySelector('div.card.mb-3');
   assert.ok(card, 'fixture should contain a card');
   return card;
+}
+
+function parseDocument(html) {
+  const { document } = parseHTML(html);
+  return document;
 }
 
 test('fixture: title tooltip score -> tried', () => {
@@ -76,4 +83,41 @@ test('fixture: footer score "Punctajul tau maxim" -> solved', () => {
 test('fixture: parseTotalProblems', () => {
   const html = loadFixture('list-header-total.html');
   assert.equal(parseTotalProblems(html), 187);
+});
+
+test('fixture: problem page score 100 -> solved', () => {
+  const doc = parseDocument(loadFixture('problem-page-score-100.html'));
+  const scoreInfo = extractScoreInfoFromProblemPage(doc);
+  assert.deepEqual(
+    { userScore: scoreInfo.userScore, maxScore: scoreInfo.maxScore },
+    { userScore: 100, maxScore: null }
+  );
+  assert.equal(classifyProblemStatus(scoreInfo), 'solved');
+  const meta = extractProblemMetaFromProblemPage(doc, 1);
+  assert.equal(meta.name, 'sum');
+  assert.equal(meta.difficulty, 0);
+  assert.equal(meta.author, 'Silviu Candale');
+  assert.equal(meta.source, '');
+});
+
+test('fixture: problem page score 42 -> tried', () => {
+  const doc = parseDocument(loadFixture('problem-page-score-42.html'));
+  const scoreInfo = extractScoreInfoFromProblemPage(doc);
+  assert.deepEqual(
+    { userScore: scoreInfo.userScore, maxScore: scoreInfo.maxScore },
+    { userScore: 42, maxScore: null }
+  );
+  assert.equal(classifyProblemStatus(scoreInfo), 'tried');
+});
+
+test('fixture: problem page without score cell -> unattempted', () => {
+  const doc = parseDocument(loadFixture('problem-page-no-score.html'));
+  const scoreInfo = extractScoreInfoFromProblemPage(doc);
+  assert.deepEqual(
+    { userScore: scoreInfo.userScore, maxScore: scoreInfo.maxScore },
+    { userScore: null, maxScore: null }
+  );
+  assert.equal(classifyProblemStatus(scoreInfo), 'unattempted');
+  const meta = extractProblemMetaFromProblemPage(doc, 8000);
+  assert.equal(meta.name, 'Pagina nu există.');
 });

--- a/tests/html-fixtures.test.js
+++ b/tests/html-fixtures.test.js
@@ -63,6 +63,16 @@ test('fixture: ambiguous 100p -> unattempted', () => {
   assert.equal(classifyProblemStatus(info), 'unattempted');
 });
 
+test('fixture: footer score "Punctajul tau maxim" -> solved', () => {
+  const card = parseCard(loadFixture('card-score-footer-user-max.html'));
+  const info = extractScoreInfoFromCard(card);
+  assert.deepEqual(
+    { userScore: info.userScore, maxScore: info.maxScore },
+    { userScore: 100, maxScore: null }
+  );
+  assert.equal(classifyProblemStatus(info), 'solved');
+});
+
 test('fixture: parseTotalProblems', () => {
   const html = loadFixture('list-header-total.html');
   assert.equal(parseTotalProblems(html), 187);

--- a/tests/score-parsing.test.js
+++ b/tests/score-parsing.test.js
@@ -17,7 +17,14 @@ test('parseScoreText: points', () => {
 
 test('selectScoreFromCandidates: max only => unknown user score', () => {
   const res = selectScoreFromCandidates([
-    { tooltip: 'Punctaj maxim', text: '100p', value: 100, max: null, hasRatio: false, isLink: false },
+    {
+      tooltip: 'Punctaj maxim',
+      text: '100p',
+      value: 100,
+      max: null,
+      hasRatio: false,
+      isLink: false,
+    },
   ]);
   assert.deepEqual(res, { userScore: null, maxScore: 100 });
 });
@@ -31,7 +38,14 @@ test('selectScoreFromCandidates: single ambiguous 100p => treat as max', () => {
 
 test('selectScoreFromCandidates: prefer obtained over max', () => {
   const res = selectScoreFromCandidates([
-    { tooltip: 'Punctaj maxim', text: '100p', value: 100, max: null, hasRatio: false, isLink: false },
+    {
+      tooltip: 'Punctaj maxim',
+      text: '100p',
+      value: 100,
+      max: null,
+      hasRatio: false,
+      isLink: false,
+    },
     { tooltip: 'Punctaj obținut', text: '0p', value: 0, max: null, hasRatio: false, isLink: false },
   ]);
   assert.deepEqual(res, { userScore: 0, maxScore: 100 });
@@ -39,7 +53,14 @@ test('selectScoreFromCandidates: prefer obtained over max', () => {
 
 test('selectScoreFromCandidates: ratio provides max', () => {
   const res = selectScoreFromCandidates([
-    { tooltip: 'Punctaj obținut', text: '30/100', value: 30, max: 100, hasRatio: true, isLink: false },
+    {
+      tooltip: 'Punctaj obținut',
+      text: '30/100',
+      value: 30,
+      max: 100,
+      hasRatio: true,
+      isLink: false,
+    },
   ]);
   assert.deepEqual(res, { userScore: 30, maxScore: 100 });
 });

--- a/tests/score-parsing.test.js
+++ b/tests/score-parsing.test.js
@@ -22,6 +22,13 @@ test('selectScoreFromCandidates: max only => unknown user score', () => {
   assert.deepEqual(res, { userScore: null, maxScore: 100 });
 });
 
+test('selectScoreFromCandidates: single ambiguous 100p => treat as max', () => {
+  const res = selectScoreFromCandidates([
+    { tooltip: 'Punctaj', text: '100p', value: 100, max: null, hasRatio: false, isLink: false },
+  ]);
+  assert.deepEqual(res, { userScore: null, maxScore: 100 });
+});
+
 test('selectScoreFromCandidates: prefer obtained over max', () => {
   const res = selectScoreFromCandidates([
     { tooltip: 'Punctaj maxim', text: '100p', value: 100, max: null, hasRatio: false, isLink: false },

--- a/tests/score-parsing.test.js
+++ b/tests/score-parsing.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseScoreText, selectScoreFromCandidates } = require('../pbinfo-get-unsolved-enhanced.js');
+
+test('parseScoreText: ratio', () => {
+  assert.deepEqual(parseScoreText(' 65/100 '), { value: 65, max: 100, hasRatio: true });
+});
+
+test('parseScoreText: percent', () => {
+  assert.deepEqual(parseScoreText('75%'), { value: 75, max: 100, hasRatio: false });
+});
+
+test('parseScoreText: points', () => {
+  assert.deepEqual(parseScoreText('100p'), { value: 100, max: null, hasRatio: false });
+});
+
+test('selectScoreFromCandidates: max only => unknown user score', () => {
+  const res = selectScoreFromCandidates([
+    { tooltip: 'Punctaj maxim', text: '100p', value: 100, max: null, hasRatio: false, isLink: false },
+  ]);
+  assert.deepEqual(res, { userScore: null, maxScore: 100 });
+});
+
+test('selectScoreFromCandidates: prefer obtained over max', () => {
+  const res = selectScoreFromCandidates([
+    { tooltip: 'Punctaj maxim', text: '100p', value: 100, max: null, hasRatio: false, isLink: false },
+    { tooltip: 'Punctaj obținut', text: '0p', value: 0, max: null, hasRatio: false, isLink: false },
+  ]);
+  assert.deepEqual(res, { userScore: 0, maxScore: 100 });
+});
+
+test('selectScoreFromCandidates: ratio provides max', () => {
+  const res = selectScoreFromCandidates([
+    { tooltip: 'Punctaj obținut', text: '30/100', value: 30, max: 100, hasRatio: true, isLink: false },
+  ]);
+  assert.deepEqual(res, { userScore: 30, maxScore: 100 });
+});
+
+test('selectScoreFromCandidates: ratio beats plain value', () => {
+  const res = selectScoreFromCandidates([
+    { tooltip: 'Punctaj', text: '100p', value: 100, max: null, hasRatio: false, isLink: false },
+    { tooltip: 'Punctaj', text: '30/100', value: 30, max: 100, hasRatio: true, isLink: false },
+  ]);
+  assert.deepEqual(res, { userScore: 30, maxScore: 100 });
+});

--- a/tests/state-snapshot.test.js
+++ b/tests/state-snapshot.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  serializeProblemForSnapshot,
+  restoreProblemsFromSnapshot,
+  computeResumeFromStateSnapshot,
+} = require('../pbinfo-get-unsolved-enhanced.js');
+
+test('snapshot: computeResumeFromStateSnapshot picks lowest outstanding index', () => {
+  assert.equal(
+    computeResumeFromStateSnapshot({
+      pageQueue: [10, 11],
+      deferred: [[12, 1]],
+      inFlightPages: [13],
+      nextSequentialPage: 14,
+    }),
+    10
+  );
+
+  assert.equal(
+    computeResumeFromStateSnapshot({
+      deferred: [
+        [9, 1],
+        [3, 2],
+      ],
+    }),
+    3
+  );
+
+  assert.equal(computeResumeFromStateSnapshot({}), null);
+});
+
+test('snapshot: serialize/restore problems roundtrip', () => {
+  const original = {
+    id: 42,
+    name: 'foo',
+    link: 'https://www.pbinfo.ro/probleme/42/foo',
+    difficulty: 1,
+    status: 'tried',
+    userScore: 55,
+    maxScore: 100,
+    postedBy_link: 'https://www.pbinfo.ro/utilizator/1/x',
+    postedBy_name: 'X',
+    postedBy_img: 'https://example.com/avatar.png',
+    author: 'Author',
+    source: 'Source',
+  };
+
+  const snapshot = {
+    problems: [serializeProblemForSnapshot(original, 'full')],
+    seenProblemIds: [42],
+  };
+
+  const restored = restoreProblemsFromSnapshot(snapshot);
+  assert.equal(restored.allProblems.length, 1);
+  assert.ok(restored.seenProblemIds.has(42));
+
+  const p = restored.allProblems[0];
+  assert.equal(p.id, 42);
+  assert.equal(p.name, 'foo');
+  assert.equal(p.link, 'https://www.pbinfo.ro/probleme/42/foo');
+  assert.equal(p.difficulty, 1);
+  assert.equal(p.status, 'tried');
+  assert.equal(p.userScore, 55);
+  assert.equal(p.maxScore, 100);
+  assert.equal(p.scoreKnown, true);
+  assert.equal(p.score, 55);
+  assert.equal(p.postedBy_name, 'X');
+  assert.equal(p.author, 'Author');
+  assert.equal(p.source, 'Source');
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,7 +1,12 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { normalizeListUrl, buildPageUrl, problemsToCsv } = require('../pbinfo-get-unsolved-enhanced.js');
+const {
+  normalizeListUrl,
+  buildPageUrl,
+  problemsToCsv,
+  problemsToLinksText,
+} = require('../pbinfo-get-unsolved-enhanced.js');
 
 test('normalizeListUrl: strips pagination param', () => {
   const url = normalizeListUrl(
@@ -53,3 +58,10 @@ test('problemsToCsv: escapes values and includes BOM', () => {
   assert.ok(csv.includes('"Sursă, cu virgulă"'));
 });
 
+test('problemsToLinksText: joins links by newline', () => {
+  const text = problemsToLinksText([
+    { link: 'https://www.pbinfo.ro/probleme/1/a' },
+    { link: 'https://www.pbinfo.ro/probleme/2/b' },
+  ]);
+  assert.equal(text, 'https://www.pbinfo.ro/probleme/1/a\nhttps://www.pbinfo.ro/probleme/2/b');
+});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { normalizeListUrl, buildPageUrl, problemsToCsv } = require('../pbinfo-get-unsolved-enhanced.js');
+
+test('normalizeListUrl: strips pagination param', () => {
+  const url = normalizeListUrl(
+    'https://www.pbinfo.ro/?pagina=probleme-lista&start=20&clasa=1',
+    'https://www.pbinfo.ro/?pagina=probleme-lista',
+    'start'
+  );
+  assert.equal(url, 'https://www.pbinfo.ro/?pagina=probleme-lista&clasa=1');
+});
+
+test('buildPageUrl: offset mode (start)', () => {
+  const url = buildPageUrl('https://www.pbinfo.ro/?pagina=probleme-lista&clasa=1', {
+    pageIndex: 3,
+    pageSize: 10,
+    mode: 'offset',
+    param: 'start',
+  });
+  assert.equal(url, 'https://www.pbinfo.ro/?pagina=probleme-lista&clasa=1&start=20');
+});
+
+test('buildPageUrl: page mode', () => {
+  const url = buildPageUrl('https://www.pbinfo.ro/?pagina=probleme-lista&clasa=1', {
+    pageIndex: 3,
+    pageSize: 10,
+    mode: 'page',
+    param: 'page',
+    pageBase: 1,
+  });
+  assert.equal(url, 'https://www.pbinfo.ro/?pagina=probleme-lista&clasa=1&page=3');
+});
+
+test('problemsToCsv: escapes values and includes BOM', () => {
+  const csv = problemsToCsv([
+    {
+      id: 1,
+      name: 'A "quote"',
+      status: 'tried',
+      userScore: 10,
+      maxScore: 100,
+      difficulty: 1,
+      postedBy_name: 'Nume',
+      author: 'Autor',
+      source: 'Sursă, cu virgulă',
+      link: 'https://www.pbinfo.ro/probleme/1/a',
+    },
+  ]);
+  assert.ok(csv.startsWith('\ufeffid,name,status,userScore,maxScore,difficulty,postedBy,author,source,link\n'));
+  assert.ok(csv.includes('"A ""quote"""'));
+  assert.ok(csv.includes('"Sursă, cu virgulă"'));
+});
+

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -6,6 +6,8 @@ const {
   buildPageUrl,
   problemsToCsv,
   problemsToLinksText,
+  problemsToIdsText,
+  problemsToMarkdownText,
 } = require('../pbinfo-get-unsolved-enhanced.js');
 
 test('normalizeListUrl: strips pagination param', () => {
@@ -68,4 +70,16 @@ test('problemsToLinksText: joins links by newline', () => {
     { link: 'https://www.pbinfo.ro/probleme/2/b' },
   ]);
   assert.equal(text, 'https://www.pbinfo.ro/probleme/1/a\nhttps://www.pbinfo.ro/probleme/2/b');
+});
+
+test('problemsToIdsText: joins ids by newline', () => {
+  const text = problemsToIdsText([{ id: 1 }, { id: 2 }]);
+  assert.equal(text, '1\n2');
+});
+
+test('problemsToMarkdownText: returns a markdown list', () => {
+  const text = problemsToMarkdownText([
+    { id: 1, name: 'Test [x]', link: 'https://www.pbinfo.ro/probleme/1/test' },
+  ]);
+  assert.equal(text, '- [#1 - Test \\[x\\]](<https://www.pbinfo.ro/probleme/1/test>)');
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -53,7 +53,11 @@ test('problemsToCsv: escapes values and includes BOM', () => {
       link: 'https://www.pbinfo.ro/probleme/1/a',
     },
   ]);
-  assert.ok(csv.startsWith('\ufeffid,name,status,userScore,maxScore,difficulty,postedBy,author,source,link\n'));
+  assert.ok(
+    csv.startsWith(
+      '\ufeffid,name,status,userScore,maxScore,difficulty,postedBy,author,source,link\n'
+    )
+  );
   assert.ok(csv.includes('"A ""quote"""'));
   assert.ok(csv.includes('"Sursă, cu virgulă"'));
 });


### PR DESCRIPTION
- **Summary**
  - Modernizes the pbinfo browser-console script to more reliably detect solved/tried/unattempted problems and provides an interactive report with filtering/export.
  - Improves scan coverage and UX via an ID-range scan mode, optional overlay UI, snapshots (multiple saved states), and throttled live rendering.
- **Changes**
  - Improves score parsing across card variants (e.g. `title`/`data-bs-title`, `0/100` formats) and classifies each problem as `solved`/`tried`/`unattempted`.
  - Fixes score detection for list pages where pbinfo shows the user score inside the **Rezolvă** button (e.g. title like `Punctajul tău maxim`).
  - Adds safer scan termination (total-count aware) and stronger retry/backoff + rate limiting controls, including optional limited concurrency.
  - Adds a fallback scan cap via `PBINFO_GET_UNSOLVED_MAX_PAGES`.
  - Adds debug mode to dump per-card metadata when parsing fails.
  - Adds report UI controls (status filter, score min/max, include unknown), CSV/JSON export, and progress reporting with ETA.
  - Debounces score filter inputs to avoid expensive re-renders on large lists.
  - Adds scan UX improvements: pause/resume, stop button, start page (resume) prompt/config, and copy-to-clipboard formats (links/IDs/Markdown).
  - Improves report styling (sticky header, row hover) and adds automatic dark mode styling.
  - Adds scan state persistence to `localStorage` (autosave + manual save/load/clear) to support reload-resume.
  - Adds snapshots support (multiple saved states per link, with retention via `PBINFO_GET_UNSOLVED_SNAPSHOTS_MAX`).
  - Adds a theme toggle (system/light/dark) stored in `localStorage`.
  - Adds non-destructive overlay UI mode via `PBINFO_GET_UNSOLVED_OVERLAY` (avoids wiping the page).
  - Adds a “close overlay” control when overlay mode is enabled.
  - Adds an alternate scan mode by problem ID range (`/probleme/<id>`) and speeds it up with optional batched score fetch (`ajx-module/json-probleme-scor.php?ids=...`).
  - Fetches full problem metadata for tried scores (<100) in ID-range mode so results include name/difficulty/author/etc.
  - Skips forbidden problem IDs (HTTP 401/403) during ID-range scan instead of aborting the whole run.
  - Prompts for scan mode selection (disable via `window.PBINFO_GET_UNSOLVED_MODE_PROMPT = false`).
  - Adds fuzz tests for score parsing/HTML variation handling and unit tests for snapshot serialization/restore.
  - Adds GitHub Actions CI to run tests/lint/format checks and bookmarklet build on PRs.
  - Adds a small changelog section in README.
- **Testing**
  - `npm test` (pass)
  - `npm run lint` (pass)
  - `npm run format:check` (pass)
  - `npm run build:bookmarklet` (pass)
- **Risk & Impact**
  - Low risk; changes are limited to a copy-paste browser console script.
  - `localStorage` writes are best-effort and fall back gracefully if storage is full.
  - ID-range scanning is optional and may be impacted by rate limits; it falls back to HTML when score is unavailable.
- **Related TODO items**
  - [x] Fix unsolved detection when pbinfo shows max points instead of user score
  - [x] Add robust score parsing (title/data-bs-title variants, multiple numbers like `0/100`)
  - [x] Detect and label statuses: solved / tried / unattempted
  - [x] Add request retry/backoff on transient failures and rate limiting
  - [x] Add safer termination conditions (avoid premature stop on empty/blocked pages)
  - [x] Add debug mode to dump per-card metadata when parsing fails
  - [x] Harden report rendering (avoid `innerHTML` for pbinfo strings)
  - [x] Update README to reference `pbinfo-get-unsolved-enhanced.js` and current workflow
  - [x] Add regression tests for score parsing heuristics
  - [x] Add HTML fixture tests for common pbinfo card layouts
  - [x] Add alternate scan mode by problem ID range (`/probleme/<id>`) to avoid missing items from list filtering
  - [x] Add HTML fixture tests for problem page score cell (`#scor_utilizator_problema`)
  - [x] Consider batched score fetch for ID scans (`ajx-module/json-probleme-scor.php?ids=...`)
  - [x] Skip forbidden problem IDs (HTTP 403) during ID scan instead of aborting
  - [x] Add UI controls to filter by status and score threshold
  - [x] Add option to export results as CSV/JSON
  - [x] Improve progress reporting (ETA, pages scanned, problems scanned)
  - [x] Replace O(n²) duplicate checks with a `Set` of IDs
  - [x] Add support for both global list and category list URLs with auto-detection
  - [x] Add configurable page size / pagination strategy (in case pbinfo changes)
  - [x] Add optional concurrency (limited) for faster scanning
  - [x] Add a bookmarklet-friendly build (minified single line + instructions)
  - [x] Add ESLint + formatting to keep style consistent
  - [x] Add a “copy links to clipboard” button
  - [x] Add a “resume from page N” option
  - [x] Add a “stop scan” button during long runs
  - [x] Add a pause/resume toggle (keep scan state)
  - [x] Use `PBINFO_GET_UNSOLVED_MAX_PAGES` as a fallback termination cap
  - [x] Add extra clipboard formats (IDs / Markdown list)
  - [x] Persist scan state to `localStorage` for reload-resume
  - [x] Add better table styling (sticky header, row hover)
  - [x] Add dark mode styling for the generated report
  - [x] Add theme toggle (system/light/dark)
  - [x] Add a small changelog section in README
  - [x] Add GitHub Actions to run tests on PRs
  - [x] Add throttled live rendering during scan (optional)
  - [x] Store and select from multiple saved states (per link)
  - [x] Add unit tests for state snapshot serialization/restore
  - [x] Add non-destructive overlay UI mode (avoid wiping page)
  - [x] Add fuzz tests for score parsing / HTML variations
  - [x] Add “close overlay” control (when overlay mode enabled)



